### PR TITLE
[Refactor] modal과 notice 리팩토링

### DIFF
--- a/src/main/java/com/kustaurant/kustaurant/common/modal/infrastructure/HomeModalEntity.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/modal/infrastructure/HomeModalEntity.java
@@ -13,10 +13,12 @@ import java.time.LocalDateTime;
 public class HomeModalEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer modalId;
-
-    String modalTitle;
-    String modalBody;
+    @Column(name = "modal_id")
+    private Integer id;
+    @Column(name = "modal_title")
+    String title;
+    @Column(name = "modal_body")
+    String body;
     LocalDateTime createdAt;
     LocalDateTime expiredAt;
 }

--- a/src/main/java/com/kustaurant/kustaurant/common/modal/infrastructure/HomeModalRepository.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/modal/infrastructure/HomeModalRepository.java
@@ -3,5 +3,5 @@ package com.kustaurant.kustaurant.common.modal.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HomeModalRepository extends JpaRepository<HomeModalEntity,Integer> {
-    HomeModalEntity getHomeModalByModalId(Integer Id);
+
 }

--- a/src/main/java/com/kustaurant/kustaurant/common/modal/service/HomeModalService.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/modal/service/HomeModalService.java
@@ -11,9 +11,10 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class HomeModalService {
     private final HomeModalRepository homeModalRepository;
+    private static final int MODAL_ID_IS_ONLY_ONE = 1;
 
     public HomeModalEntity get() {
-        return homeModalRepository.findById(1)
+        return homeModalRepository.findById(MODAL_ID_IS_ONLY_ONE)
                 .filter(modal -> modal.getExpiredAt().isAfter(LocalDateTime.now()))
                 .orElse(null);
     }

--- a/src/main/java/com/kustaurant/kustaurant/common/modal/service/HomeModalService.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/modal/service/HomeModalService.java
@@ -1,0 +1,20 @@
+package com.kustaurant.kustaurant.common.modal.service;
+
+import com.kustaurant.kustaurant.common.modal.infrastructure.HomeModalEntity;
+import com.kustaurant.kustaurant.common.modal.infrastructure.HomeModalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class HomeModalService {
+    private final HomeModalRepository homeModalRepository;
+
+    public HomeModalEntity get() {
+        return homeModalRepository.findById(1)
+                .filter(modal -> modal.getExpiredAt().isAfter(LocalDateTime.now()))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/kustaurant/kustaurant/common/notice/controller/NoticeController.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/notice/controller/NoticeController.java
@@ -1,7 +1,9 @@
 package com.kustaurant.kustaurant.common.notice.controller;
 
+import com.kustaurant.kustaurant.common.notice.domain.NoticeDTO;
 import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeEntity;
 import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeRepository;
+import com.kustaurant.kustaurant.common.notice.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,16 +11,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.List;
 
-@RequiredArgsConstructor
 @Controller
+@RequiredArgsConstructor
 public class NoticeController {
-    private final NoticeRepository noticeRepo;
+
+    private final NoticeService noticeService;
+
     @GetMapping("/notice")
-    public String notice(
+    public String getNotices(
             Model model
     ){
-        List<NoticeEntity> noticeEntity = noticeRepo.findAll();
-        model.addAttribute("Notice", noticeEntity);
+        List<NoticeDTO> notices = noticeService.getAllNotices();
+        model.addAttribute("notices", notices);
         return "notice";
     }
 

--- a/src/main/java/com/kustaurant/kustaurant/common/notice/domain/NoticeDTO.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/notice/domain/NoticeDTO.java
@@ -1,12 +1,21 @@
 package com.kustaurant.kustaurant.common.notice.domain;
 
+import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class NoticeDTO {
-    private String noticeTitle;
-    private String noticeLink;
-    private String createdDate;
+    private String title;
+    private String href;
+    private String createdAt;
+
+    public static NoticeDTO from(NoticeEntity noticeEntity) {
+        return new NoticeDTO(
+                noticeEntity.getTitle(),
+                noticeEntity.getHref(),
+                noticeEntity.getCreatedAt().toString()
+        );
+    }
 }

--- a/src/main/java/com/kustaurant/kustaurant/common/notice/infrastructure/NoticeEntity.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/notice/infrastructure/NoticeEntity.java
@@ -14,10 +14,12 @@ import java.time.LocalDateTime;
 public class NoticeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer noticeId;
+    private Integer id;
 
-    String noticeTitle;
-    String noticeHref;
+    @Column(name = "notice_title")
+    String title;
+    @Column(name = "notice_href")
+    String href;
     String status;
     LocalDate createdAt;
     LocalDateTime updatedAt;

--- a/src/main/java/com/kustaurant/kustaurant/common/notice/infrastructure/NoticeEntity.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/notice/infrastructure/NoticeEntity.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 public class NoticeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
     private Integer id;
 
     @Column(name = "notice_title")

--- a/src/main/java/com/kustaurant/kustaurant/common/notice/service/NoticeService.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/notice/service/NoticeService.java
@@ -1,0 +1,24 @@
+package com.kustaurant.kustaurant.common.notice.service;
+
+import com.kustaurant.kustaurant.common.notice.domain.NoticeDTO;
+import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeEntity;
+import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    public List<NoticeDTO> getAllNotices(){
+        List<NoticeEntity> entities = noticeRepository.findAll();
+
+        return entities.stream()
+                .map(NoticeDTO::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kustaurant/kustaurant/common/user/service/MypageApiService.java
+++ b/src/main/java/com/kustaurant/kustaurant/common/user/service/MypageApiService.java
@@ -265,8 +265,8 @@ public class MypageApiService {
     public List<NoticeDTO> getAllNotices() {
         return noticeRepo.findAll().stream()
                 .map(notice -> new NoticeDTO(
-                        notice.getNoticeTitle(),
-                        notice.getNoticeHref(),
+                        notice.getTitle(),
+                        notice.getHref(),
                         notice.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/com/kustaurant/kustaurant/web/restaurant/MainController.java
+++ b/src/main/java/com/kustaurant/kustaurant/web/restaurant/MainController.java
@@ -1,5 +1,6 @@
 package com.kustaurant.kustaurant.web.restaurant;
 
+import com.kustaurant.kustaurant.common.modal.service.HomeModalService;
 import com.kustaurant.kustaurant.common.restaurant.domain.dto.RestaurantTierDataClass;
 import com.kustaurant.kustaurant.common.restaurant.infrastructure.restaurant.RestaurantEntity;
 import com.kustaurant.kustaurant.common.restaurant.service.port.RestaurantRepository;
@@ -24,9 +25,8 @@ public class MainController {
     private final RestaurantRepository restaurantRepository;
     private final RestaurantWebService restaurantWebService;
     private final EvaluationService evaluationService;
-    private final HomeModalRepository HomeModalRepository;
+    private final HomeModalService homeModalService;
     private final CustomOAuth2UserService userService;
-    private static final Logger logger = LoggerFactory.getLogger(MainController.class);
 
     //@Value("#{'${restaurant.cuisines}'.split(',\\s*')}")
     private List<String> cuisines = Arrays.asList(
@@ -54,18 +54,17 @@ public class MainController {
     // 홈 화면
     @GetMapping("/")
     public String root(
-            Model model,
-            Principal principal
+            Model model
     ) {
         List<RestaurantEntity> restaurants = restaurantWebService.getTopRestaurants();
         List<String> cuisines = new ArrayList<>(Arrays.asList("한식","일식","중식","양식","아시안","고기","치킨","햄버거","분식","해산물","술집","샐러드","카페","베이커리","기타","전체"));
 
-        HomeModalEntity homeModalEntity = HomeModalRepository.getHomeModalByModalId(1);
+        HomeModalEntity homeModal = homeModalService.get();
 
         model.addAttribute("cuisines", cuisines);
         model.addAttribute("restaurants",restaurants);
         model.addAttribute("currentPage","home");
-        model.addAttribute("homeModalEntity", homeModalEntity);
+        model.addAttribute("homeModal", homeModal);
         return "home";
     }
 

--- a/src/main/resources/static/js/homeScript.js
+++ b/src/main/resources/static/js/homeScript.js
@@ -4,11 +4,6 @@ document.addEventListener('DOMContentLoaded', function () {
     var closeButton = document.querySelector('#modal button[data-bs-dismiss="modal"]');
     var hideCheckbox = document.getElementById("flexCheckChecked");
 
-    var expiredElement = document.getElementById('ExpiredData');
-    var expiredAtString = expiredElement.getAttribute('data-expired');
-    var expiredAt = new Date(expiredAtString);
-    var currentDate = new Date();
-
     closeButton.addEventListener("click", function() {
         var expiryDate = new Date();
         expiryDate.setDate(expiryDate.getDate() + 7); // 일주일 후의 날짜 설정
@@ -22,9 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // 쿠키에 hideModal이 없거나 그 값이 false일 경우에만 모달을 보여줌
     if (!hideModalCookie || hideModalCookie.split("=")[1] !== "true") {
-        if (currentDate < expiredAt) {
-            modal.style.display = "block";
-        }
+        modal.style.display = "block";
     }
 
     var swiper = new Swiper('.swiper', {

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -19,7 +19,7 @@
 
 
             <div class="col icon-with-text-style-03 md-mb-30px">
-                <a href="/noticeEntity">
+                <a href="/notice">
                 <div class="feature-box ps-8 pe-8 lg-ps-0 lg-pe-0 overflow-hidden">
                     <div class="feature-box-icon">
                         <i class="bi bi-megaphone-fill d-inline-block icon-medium text-dark-gray mb-15px"></i>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -326,34 +326,43 @@
         </div>
     </section>
 
+    <!-- Modal 전체를 조건부 렌더링 -->
+    <div th:if="${homeModal != null}">
 
-    <!-- Modal -->
-    <div class="modal" id="modal" data-bs-backdrop="static" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered ">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h1 class="modal-title fs-5 text-primary" id="exampleModalLabel" th:text="${homeModalEntity.modalTitle}"></h1>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
+        <!-- Modal -->
+        <div class="modal" id="modal" data-bs-backdrop="static" tabindex="-1"
+             aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
 
-                <div class="modal-body text-dark" th:utext="${homeModalEntity.modalBody}">
-                </div>
-
-                <div class="modal-body text-dark" th:text="${'(만료일: ' + homeModalEntity.expiredAt + ')'}">
-                </div>
-
-                <div class="modal-footer">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked">
-                        <label class="form-check-label" for="flexCheckChecked">
-                            일주일동안 보지 않기
-                        </label>
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5 text-primary" id="exampleModalLabel"
+                            th:text="${homeModal.title}"></h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                aria-label="Close"></button>
                     </div>
+
+                    <div class="modal-body text-dark" th:utext="${homeModal.body}">
+                    </div>
+
+                    <div class="modal-body text-dark"
+                         th:text="${'(만료일: ' + homeModal.expiredAt + ')'}">
+                    </div>
+
+                    <div class="modal-footer">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked">
+                            <label class="form-check-label" for="flexCheckChecked">
+                                일주일동안 보지 않기
+                            </label>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </div>
     </div>
-    <div id="ExpiredData" th:data-expired="${homeModalEntity.expiredAt}" style="display: none"></div>
+
 
     <footer th:replace="~{footer::footerFragment}">
 

--- a/src/main/resources/templates/notice.html
+++ b/src/main/resources/templates/notice.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="/css/library/style.min.css">
   <link rel="stylesheet" href="/css/library/responsive.min.css">
   <link rel="stylesheet" href="/css/library/restaurant.css">
-  <link rel="stylesheet" href="/css/noticeEntity-style.css">
+  <link rel="stylesheet" href="/css/notice-style.css">
   <script type="text/javascript" src="/js/library/jquery.js"></script>
   <script type="text/javascript" src="/js/library/vendors.min.js"></script>
   <script type="text/javascript" src="/js/library/main.js"></script>
@@ -35,10 +35,10 @@
     </div>
   </section>
   <div class="cardlist">
-    <div th:each="noticelist:${Notice}" class="noticeEntity-card">
+    <div th:each="noticelist:${notices}" class="notice-card">
       <a th:href="${noticelist.noticeHref}" target="_blank">
-        <p th:text="${noticelist.noticeTitle}" class="noticeEntity-title"></p>
-        <p th:text="${noticelist.createdAt}" class="noticeEntity-created-at"></p>
+        <p th:text="${noticelist.noticeTitle}" class="notice-title"></p>
+        <p th:text="${noticelist.createdAt}" class="notice-created-at"></p>
       </a>
     </div>
   </div>

--- a/src/test/java/com/kustaurant/kustaurant/common/modal/service/HomeModalServiceTest.java
+++ b/src/test/java/com/kustaurant/kustaurant/common/modal/service/HomeModalServiceTest.java
@@ -1,0 +1,64 @@
+package com.kustaurant.kustaurant.common.modal.service;
+
+import com.kustaurant.kustaurant.common.modal.infrastructure.HomeModalEntity;
+import com.kustaurant.kustaurant.common.modal.infrastructure.HomeModalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HomeModalServiceTest {
+
+    private HomeModalRepository homeModalRepository;
+    private HomeModalService homeModalService;
+
+    @BeforeEach
+    void setUp() {
+        homeModalRepository = mock(HomeModalRepository.class);
+        homeModalService = new HomeModalService(homeModalRepository);
+    }
+
+    @Test
+    void 만료되지_않은_modal은_조회된다(){
+        //g
+        //테스트시간
+        LocalDateTime testTime = LocalDateTime.of(2025, 4, 3, 12, 0);
+
+        HomeModalEntity modal = new HomeModalEntity();
+        modal.setTitle("유효한 모달");
+        modal.setCreatedAt(testTime.minusDays(1));
+        modal.setExpiredAt(testTime.plusDays(1));
+
+        when(homeModalRepository.findById(1)).thenReturn(Optional.of(modal));
+
+        //w
+        HomeModalEntity result = homeModalService.get();
+
+        //t
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("유효한 모달");
+    }
+
+    @Test
+    void 만료된_모달은_null을_반환한다() {
+        // given
+        HomeModalEntity expiredModal = new HomeModalEntity();
+        expiredModal.setTitle("만료된 모달");
+        expiredModal.setCreatedAt(LocalDateTime.now().minusDays(2));
+        expiredModal.setExpiredAt(LocalDateTime.now().minusHours(1)); // 만료됨
+
+        when(homeModalRepository.findById(1)).thenReturn(Optional.of(expiredModal));
+
+        // when
+        HomeModalEntity result = homeModalService.get();
+
+        // then
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/kustaurant/kustaurant/common/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/kustaurant/kustaurant/common/notice/service/NoticeServiceTest.java
@@ -1,0 +1,55 @@
+package com.kustaurant.kustaurant.common.notice.service;
+
+import com.kustaurant.kustaurant.common.notice.domain.NoticeDTO;
+import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeEntity;
+import com.kustaurant.kustaurant.common.notice.infrastructure.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+class NoticeServiceTest {
+
+    private NoticeRepository noticeRepository;
+    private NoticeService noticeService;
+
+    @BeforeEach
+    void setUp() {
+        noticeRepository = mock(NoticeRepository.class);
+        noticeService = new NoticeService(noticeRepository);
+    }
+
+    @Test
+    void getAllNotices는_noticeDTO리스트들을_잘_불러온다(){
+        //g
+        NoticeEntity n1= new NoticeEntity();
+        n1.setTitle("첫 번째 테스트 공지");
+        n1.setHref("https://kustaurant.com");
+        n1.setCreatedAt(LocalDate.of(2025,4,2));
+        NoticeEntity n2= new NoticeEntity();
+        n2.setTitle("두 번째 테스트 공지");
+        n2.setHref("https://kustaurant.com");
+        n2.setCreatedAt(LocalDate.of(2025,4,3));
+
+        when(noticeRepository.findAll()).thenReturn(Arrays.asList(n1,n2));
+
+        //w
+        List<NoticeDTO> result= noticeService.getAllNotices();
+
+        //t
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("첫 번째 테스트 공지");
+
+        //v
+        verify(noticeRepository, times(1)).findAll();
+    }
+
+}

--- a/src/test/java/com/kustaurant/kustaurant/common/restaurant/service/RestaurantFavoriteServiceTest.java
+++ b/src/test/java/com/kustaurant/kustaurant/common/restaurant/service/RestaurantFavoriteServiceTest.java
@@ -4,7 +4,7 @@ import com.kustaurant.kustaurant.common.mock.FakeRestaurantFavoriteRepository;
 import com.kustaurant.kustaurant.common.restaurant.domain.Restaurant;
 import com.kustaurant.kustaurant.common.restaurant.domain.RestaurantFavorite;
 import com.kustaurant.kustaurant.common.restaurant.service.port.RestaurantFavoriteRepository;
-import com.kustaurant.kustaurant.common.user.infrastructure.User;
+import com.kustaurant.kustaurant.common.user.infrastructure.UserEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 즐겨찾기_추가() {
         // Given
-        User user = new User();
+        UserEntity user = new UserEntity();
         user.setUserId(1);
         Restaurant restaurant = Restaurant.builder()
                 .restaurantId(1)
@@ -41,7 +41,7 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 즐겨찾기_삭제() {
         // Given
-        User user = new User();
+        UserEntity user = new UserEntity();
         user.setUserId(1);
         Restaurant restaurant = Restaurant.builder()
                 .restaurantId(1)
@@ -62,7 +62,7 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 새로_즐겨찾기_추가하는_경우() {
         // Given
-        User user = new User();
+        UserEntity user = new UserEntity();
         user.setUserId(1);
         Restaurant restaurant = Restaurant.builder()
                 .restaurantId(1)
@@ -81,7 +81,7 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 이전에_즐겨찾기가_되어_있었던_경우() {
         // Given
-        User user = new User();
+        UserEntity user = new UserEntity();
         user.setUserId(1);
         Restaurant restaurant = Restaurant.builder()
                 .restaurantId(1)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

- homeModal과 notice는 너무 사소한 기능이라 복잡한 추상화를 진행하지 않았습니다. 
- 두개 모두 컨트롤러에서 레포를 참조하던 방식에서 서비스 레이어를 두어 컨트롤러 -> 서비스 ->레포 방식으로 의존하도록 변경

-- homeModal --
- 기존에 서버 로직에서 한결같이 homeModal을 전달하고, expiredAt 기간에 따라 html와js 상에서 렌더링 할지말지결정 하던 방식에서
서버에서 expiredAt에 따라 만료되지 않은 경우에만 조회 가능하도록 넘겨주고 아닌경우 null을 반환하도록 수정했습니다.
- 하나의 엔티티만 두어 본문내용, 기간 등만 변경해서 사용하는 방식이기에 도메인엔티티를 별도로 두지 않고 DB엔티티만 사용하도록 하였습니다. 

-- noticeModal --
- 모바일은 웹뷰를 사용하기 때문에 웹코드만 수정되었습니다. 마찬가지로 별도의 복잡한 기능을 사용하지 않을예정이기에 도메인엔티티를 별도로 두지 않고 DTO를 두어 사용하였습니다.

<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제