### PR TITLE
[fix] 식당 상세 화면 정상화 1

### DIFF
--- a/src/main/java/com/kustaurant/kustaurant/evaluation/controller/api/EvaluationApiController.java
+++ b/src/main/java/com/kustaurant/kustaurant/evaluation/controller/api/EvaluationApiController.java
@@ -131,7 +131,7 @@ public class EvaluationApiController {
         // 평가 추가하기 혹은 기존 평가 업데이트하기
         evaluationService.createOrUpdate(UserEntity, restaurant, evaluationDTO);
         // 평가 완료 후에 업데이트된 식당 데이터를 다시 반환
-        return new ResponseEntity<>(restaurantCommentService.getRestaurantCommentList(restaurantId, UserEntity, true, userAgent), HttpStatus.OK);
+        return new ResponseEntity<>(restaurantCommentService.getRestaurantCommentList(restaurantId, userId, true, userAgent), HttpStatus.OK);
     }
 
     // 리뷰 불러오기
@@ -171,7 +171,7 @@ public class EvaluationApiController {
         // 유져 가져오기
         UserEntity UserEntity = userService.findUserById(userId);
         // 이 식당의 댓글 리스트 가져오기
-        List<RestaurantCommentDTO> response = restaurantCommentService.getRestaurantCommentList(restaurantId, UserEntity, sort.equals("popularity"), userAgent);
+        List<RestaurantCommentDTO> response = restaurantCommentService.getRestaurantCommentList(restaurantId, userId, sort.equals("popularity"), userAgent);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -216,7 +216,7 @@ public class EvaluationApiController {
             // 평가 가져오기
             EvaluationEntity evaluation = evaluationService.getByEvaluationId(commentId);
             // 댓글 좋아요 로직
-            evaluationService.likeEvaluation(UserEntity, evaluation);
+            evaluationService.likeEvaluation(userId, evaluation);
 
             return ResponseEntity.ok(RestaurantCommentDTO.convertCommentWhenLikeDislike(evaluation, UserEntity));
         } else { // 대댓글인 경우
@@ -225,9 +225,9 @@ public class EvaluationApiController {
             RestaurantComment restaurantComment = restaurantCommentService.findCommentByCommentId(commentId);
             // 대댓글 좋아요 로직
             Map<String, String> responseMap = new HashMap<>();
-            restaurantCommentService.likeComment(UserEntity, restaurantComment, responseMap);
+            restaurantCommentService.likeComment(userId, restaurantComment, responseMap);
 
-            return ResponseEntity.ok(RestaurantCommentDTO.convertCommentWhenLikeDislike(restaurantComment, UserEntity));
+            return ResponseEntity.ok(RestaurantCommentDTO.convertCommentWhenLikeDislike(restaurantComment, UserEntity.getUserId()));
         }
     }
 
@@ -271,7 +271,7 @@ public class EvaluationApiController {
             // 평가 가져오기
             EvaluationEntity evaluation = evaluationService.getByEvaluationId(commentId);
             // 댓글 좋아요 로직
-            evaluationService.dislikeEvaluation(UserEntity, evaluation);
+            evaluationService.dislikeEvaluation(userId, evaluation);
 
             return ResponseEntity.ok(RestaurantCommentDTO.convertCommentWhenLikeDislike(evaluation, UserEntity));
         } else { // 대댓글인 경우
@@ -280,9 +280,9 @@ public class EvaluationApiController {
             RestaurantComment restaurantComment = restaurantCommentService.findCommentByCommentId(commentId);
             // 대댓글 좋아요 로직
             Map<String, String> responseMap = new HashMap<>();
-            restaurantCommentService.dislikeComment(UserEntity, restaurantComment, responseMap);
+            restaurantCommentService.dislikeComment(userId, restaurantComment, responseMap);
 
-            return ResponseEntity.ok(RestaurantCommentDTO.convertCommentWhenLikeDislike(restaurantComment, UserEntity));
+            return ResponseEntity.ok(RestaurantCommentDTO.convertCommentWhenLikeDislike(restaurantComment, UserEntity.getUserId()));
         }
     }
 
@@ -332,7 +332,7 @@ public class EvaluationApiController {
         // 대댓글 달기
         RestaurantComment restaurantComment = restaurantCommentService.addSubComment(restaurant, UserEntity, commentBody, evaluation);
 
-        return new ResponseEntity<>(RestaurantCommentDTO.convertCommentWhenSubComment(restaurantComment, null, UserEntity, userAgent), HttpStatus.OK);
+        return new ResponseEntity<>(RestaurantCommentDTO.convertCommentWhenSubComment(restaurantComment, null, userId, userAgent), HttpStatus.OK);
     }
 
     private void checkRestaurantIdAndEvaluationId(RestaurantEntity restaurant, int restaurantId, int evaluationId) {

--- a/src/main/java/com/kustaurant/kustaurant/evaluation/controller/web/EvaluationWebController.java
+++ b/src/main/java/com/kustaurant/kustaurant/evaluation/controller/web/EvaluationWebController.java
@@ -2,6 +2,7 @@
 
     import com.google.gson.Gson;
     import com.google.gson.reflect.TypeToken;
+    import com.kustaurant.kustaurant.global.auth.argumentResolver.JwtToken;
     import com.kustaurant.kustaurant.restaurant.application.service.command.RestaurantCommentService;
     import com.kustaurant.kustaurant.restaurant.application.service.command.dto.RestaurantCommentDTO;
     import com.kustaurant.kustaurant.restaurant.infrastructure.entity.RestaurantEntity;
@@ -18,6 +19,7 @@
     import com.kustaurant.kustaurant.evaluation.service.EvaluationService;
 
     import com.kustaurant.kustaurant.web.main.MainController;
+    import io.swagger.v3.oas.annotations.Parameter;
     import lombok.RequiredArgsConstructor;
     import org.slf4j.Logger;
     import org.slf4j.LoggerFactory;
@@ -36,14 +38,12 @@
 
     @RequiredArgsConstructor
     @Controller
-    public class EvaluationController {
+    public class EvaluationWebController {
         private final RestaurantWebService restaurantWebService;
         private final EvaluationService evaluationService;
         private final CustomOAuth2UserService customOAuth2UserService;
         private final EvaluationRepository evaluationRepository;
         private final RestaurantCommentService restaurantCommentService;
-
-        Gson gson = new Gson();
 
         private static final Logger logger = LoggerFactory.getLogger(MainController.class);
 
@@ -61,7 +61,7 @@
             Double mainScore = 0.0;
             model.addAttribute("restaurant", restaurant);
 
-            if (evaluation!=null) {
+            if (evaluation != null) {
                 model.addAttribute("eval",evaluation);
                 model.addAttribute("mainScore", evaluation.getEvaluationScore());
                 if(evaluation.getSituationIdList()!=null){
@@ -102,50 +102,21 @@
             return ResponseEntity.ok("평가가 성공적으로 저장되었습니다.");
         }
 
-        // 식당 댓글 작성
-        @PreAuthorize("isAuthenticated() and hasRole('USER')")
-        @PostMapping("/api/restaurants/{restaurantId}/comments")
-        public ResponseEntity<String> postRestaurantComment(
-                @PathVariable Integer restaurantId,
-                @RequestBody Map<String, Object> jsonBody,
-                Principal principal
-        ) {
-            String commentBody = jsonBody.get("commentBody").toString();
-            if (commentBody.isEmpty()) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("내용을 입력해 주세요.");
-            }
-            String result = restaurantCommentService.addComment(
-                    restaurantId,
-                    principal.getName(),
-                    commentBody);
-            if (result.equals("ok")) {
-                return ResponseEntity.ok("Comment added successfully");
-            } else if (result.equals("userTokenId")) {
-                return ResponseEntity.ok("UserTokenId doesn't exist");
-            } else {
-                return ResponseEntity.ok("what");
-            }
-        }
-
         // 식당 댓글 목록 html 로드
-        @GetMapping("/api/restaurants/{restaurantId}/comments")
+        @GetMapping("/web/api/restaurants/{restaurantId}/comments")
         public String getRestaurantCommentByRestaurantId(
                 @PathVariable Integer restaurantId,
                 @RequestParam(value = "sort", defaultValue = "POPULAR") String sort,
-                Principal principal,
+                @Parameter(hidden = true) @JwtToken Integer userId,
                 Model model
         ) {
             EnumSortComment sortComment = EnumSortComment.valueOf(sort);
 
-            if (principal == null) {
+            if (userId == null) {
                 List<RestaurantCommentDTO> restaurantComments = restaurantCommentService.getRestaurantCommentList(restaurantId, null, sortComment.equals(EnumSortComment.POPULAR), "ios");
                 model.addAttribute("restaurantComments", restaurantComments);
             } else {
-                UserEntity UserEntity = customOAuth2UserService.getUser(principal.getName());
-
-                model.addAttribute("user", UserEntity);
-
-                List<RestaurantCommentDTO> restaurantComments = restaurantCommentService.getRestaurantCommentList(restaurantId, UserEntity, sortComment.equals(EnumSortComment.POPULAR), "ios");
+                List<RestaurantCommentDTO> restaurantComments = restaurantCommentService.getRestaurantCommentList(restaurantId, userId, sortComment.equals(EnumSortComment.POPULAR), "ios");
                 model.addAttribute("restaurantComments", restaurantComments);
             }
 
@@ -153,20 +124,16 @@
         }
 
         // 식당 댓글 하나 html 로드
-        @GetMapping("/api/restaurants/comments/{evaluationId}")
+        @GetMapping("/web/api/restaurants/comments/{evaluationId}")
         public String getARenderedRestaurantCommentHtml(
                 Model model,
                 @PathVariable Integer evaluationId,
-                Principal principal
+                @Parameter(hidden = true) @JwtToken Integer userId
         ) {
             evaluationId -= EvaluationConstants.EVALUATION_ID_OFFSET;
 
-            if (principal != null) {
-                UserEntity UserEntity = customOAuth2UserService.getUser(principal.getName());
-
-                model.addAttribute("user", UserEntity);
-
-                RestaurantCommentDTO restaurantCommentDTO = restaurantCommentService.getRestaurantCommentDTO(evaluationId, UserEntity, "ios");
+            if (userId != null) {
+                RestaurantCommentDTO restaurantCommentDTO = restaurantCommentService.getRestaurantCommentDTO(evaluationId, userId, "ios");
                 model.addAttribute("restaurantComment", restaurantCommentDTO);
             } else {
                 RestaurantCommentDTO restaurantCommentDTO = restaurantCommentService.getRestaurantCommentDTO(evaluationId, null, "ios");
@@ -181,21 +148,20 @@
 
         // 식당 댓글 좋아요
         @PreAuthorize("isAuthenticated() and hasRole('USER')")
-        @GetMapping("/api/restaurants/comments/{commentId}/like")
+        @GetMapping("/web/api/restaurants/comments/{commentId}/like")
         public ResponseEntity<Map<String, String>> likeRestaurantComment(
                 @PathVariable Integer commentId,
-                Principal principal
+                @Parameter(hidden = true) @JwtToken Integer userId
         ) {
             Map<String, String> responseMap = new HashMap<>();
             try {
-                UserEntity UserEntity = customOAuth2UserService.getUser(principal.getName());
                 if (isSubComment(commentId)) { // 대댓글인 경우
                     RestaurantComment restaurantComment = restaurantCommentService.findCommentByCommentId(commentId);
-                    restaurantCommentService.likeComment(UserEntity, restaurantComment, responseMap);
+                    restaurantCommentService.likeComment(userId, restaurantComment, responseMap);
                 } else { // 부모 댓글인 경우
                     int evaluationId = commentId - EvaluationConstants.EVALUATION_ID_OFFSET;
                     EvaluationEntity evaluation = evaluationService.getByEvaluationId(evaluationId);
-                    evaluationService.likeEvaluation(UserEntity, evaluation);
+                    evaluationService.likeEvaluation(userId, evaluation);
                 }
             } catch (DataNotFoundException e) {
                 logger.error("RestaurantCommentLikeError", e);
@@ -213,21 +179,20 @@
 
         // 식당 댓글 싫어요
         @PreAuthorize("isAuthenticated() and hasRole('USER')")
-        @GetMapping("/api/restaurants/comments/{commentId}/dislike")
+        @GetMapping("/web/api/restaurants/comments/{commentId}/dislike")
         public ResponseEntity<Map<String, String>> dislikeRestaurantComment(
                 @PathVariable Integer commentId,
-                Principal principal
+                @Parameter(hidden = true) @JwtToken Integer userId
         ) {
             Map<String, String> responseMap = new HashMap<>();
             try {
-                UserEntity UserEntity = customOAuth2UserService.getUser(principal.getName());
                 if (isSubComment(commentId)) { // 대댓글인 경우
                     RestaurantComment restaurantComment = restaurantCommentService.findCommentByCommentId(commentId);
-                    restaurantCommentService.dislikeComment(UserEntity, restaurantComment, responseMap);
+                    restaurantCommentService.dislikeComment(userId, restaurantComment, responseMap);
                 } else { // 부모 댓글인 경우
                     int evaluationId = commentId - EvaluationConstants.EVALUATION_ID_OFFSET;
                     EvaluationEntity evaluation = evaluationService.getByEvaluationId(evaluationId);
-                    evaluationService.dislikeEvaluation(UserEntity, evaluation);
+                    evaluationService.dislikeEvaluation(userId, evaluation);
                 }
             } catch (DataNotFoundException e) {
                 logger.error("RestaurantCommentDislikeError", e);
@@ -245,7 +210,7 @@
 
         // 식당 댓글 삭제
         @PreAuthorize("isAuthenticated() and hasRole('USER')")
-        @DeleteMapping("/api/restaurants/comments/{commentId}")
+        @DeleteMapping("/web/api/restaurants/comments/{commentId}")
         public ResponseEntity<String> deleteRestaurantComment(
                 @PathVariable Integer commentId,
                 Principal principal

--- a/src/main/java/com/kustaurant/kustaurant/evaluation/controller/web/EvaluationWebController.java
+++ b/src/main/java/com/kustaurant/kustaurant/evaluation/controller/web/EvaluationWebController.java
@@ -148,7 +148,7 @@
 
         // 식당 댓글 좋아요
         @PreAuthorize("isAuthenticated() and hasRole('USER')")
-        @GetMapping("/web/api/restaurants/comments/{commentId}/like")
+        @PostMapping("/web/api/restaurants/comments/{commentId}/like")
         public ResponseEntity<Map<String, String>> likeRestaurantComment(
                 @PathVariable Integer commentId,
                 @Parameter(hidden = true) @JwtToken Integer userId
@@ -179,7 +179,7 @@
 
         // 식당 댓글 싫어요
         @PreAuthorize("isAuthenticated() and hasRole('USER')")
-        @GetMapping("/web/api/restaurants/comments/{commentId}/dislike")
+        @PostMapping("/web/api/restaurants/comments/{commentId}/dislike")
         public ResponseEntity<Map<String, String>> dislikeRestaurantComment(
                 @PathVariable Integer commentId,
                 @Parameter(hidden = true) @JwtToken Integer userId

--- a/src/main/java/com/kustaurant/kustaurant/evaluation/infrastructure/EvaluationEntity.java
+++ b/src/main/java/com/kustaurant/kustaurant/evaluation/infrastructure/EvaluationEntity.java
@@ -50,7 +50,7 @@ public class EvaluationEntity {
     @OneToMany(mappedBy = "evaluation")
     private List<RestaurantCommentDislike> restaurantCommentDislikeList = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
@@ -66,7 +66,7 @@ public class EvaluationEntity {
     private List<RestaurantComment> restaurantCommentList = new ArrayList<>();
 
     @JsonIgnore
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="restaurant_id")
     private RestaurantEntity restaurant;
 

--- a/src/main/java/com/kustaurant/kustaurant/evaluation/infrastructure/RestaurantCommentDislikeRepository.java
+++ b/src/main/java/com/kustaurant/kustaurant/evaluation/infrastructure/RestaurantCommentDislikeRepository.java
@@ -1,12 +1,17 @@
 package com.kustaurant.kustaurant.evaluation.infrastructure;
 
-import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RestaurantCommentDislikeRepository extends JpaRepository<RestaurantCommentDislike, Integer> {
-    Optional<RestaurantCommentDislike> findByUserAndRestaurantComment(UserEntity UserEntity, RestaurantComment restaurantComment);
+    @Query("select d from RestaurantCommentDislike d "
+            + "where d.user.userId = :userId and d.restaurantComment.commentId = :commentId")
+    Optional<RestaurantCommentDislike> findByUserIdAndRestaurantCommentId(@Param("userId") Integer userId, @Param("commentId") Integer commentId);
 
-    Optional<RestaurantCommentDislike> findByUserAndEvaluation(UserEntity UserEntity, EvaluationEntity evaluation);
+    @Query("select d from RestaurantCommentDislike d "
+            + "where d.user.userId = :userId and d.evaluation.evaluationId = :evaluationId")
+    Optional<RestaurantCommentDislike> findByUserIdAndEvaluationId(@Param("userId") Integer userId, @Param("evaluationId") Integer evaluationId);
 }

--- a/src/main/java/com/kustaurant/kustaurant/evaluation/infrastructure/RestaurantCommentLikeRepository.java
+++ b/src/main/java/com/kustaurant/kustaurant/evaluation/infrastructure/RestaurantCommentLikeRepository.java
@@ -1,12 +1,18 @@
 package com.kustaurant.kustaurant.evaluation.infrastructure;
 
-import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RestaurantCommentLikeRepository extends JpaRepository<RestaurantCommentLike, Integer> {
-    Optional<RestaurantCommentLike> findByUserAndRestaurantComment(UserEntity UserEntity, RestaurantComment restaurantComment);
 
-    Optional<RestaurantCommentLike> findByUserAndEvaluation(UserEntity UserEntity, EvaluationEntity evaluation);
+    @Query("select l from RestaurantCommentLike l "
+            + "where l.user.userId = :userId and l.restaurantComment.commentId = :commentId")
+    Optional<RestaurantCommentLike> findByUserIdAndRestaurantCommentId(@Param("userId") Integer userId, @Param("commentId") Integer commentId);
+
+    @Query("select l from RestaurantCommentLike l "
+            + "where l.user.userId = :userId and l.evaluation.evaluationId = :evaluationId")
+    Optional<RestaurantCommentLike> findByUserIdAndEvaluationId(@Param("userId") Integer userId, @Param("evaluationId") Integer evaluationId);
 }

--- a/src/main/java/com/kustaurant/kustaurant/global/auth/argumentResolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/kustaurant/kustaurant/global/auth/argumentResolver/AuthUserArgumentResolver.java
@@ -4,6 +4,7 @@ import com.kustaurant.kustaurant.global.auth.session.CustomOAuth2User;
 import com.kustaurant.kustaurant.user.domain.enums.UserRole;
 import com.kustaurant.kustaurant.global.exception.exception.auth.UnauthenticatedException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -42,7 +43,9 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             userId = oAuthUser.getUserId();
         } else if (auth.getPrincipal() instanceof Integer uid) {                // 앱 JWT
             userId = uid;
-        } else {
+        } else if (auth.getPrincipal() instanceof String s && "anonymousUser".equals(s)) {
+            return new AuthUserInfo(null, UserRole.GUEST);
+        }else {
             throw new UnauthenticatedException(
                     "지원하지 않는 principal 타입: " + auth.getPrincipal().getClass().getName());
         }

--- a/src/main/java/com/kustaurant/kustaurant/global/config/security/SecurityWebConfig.java
+++ b/src/main/java/com/kustaurant/kustaurant/global/config/security/SecurityWebConfig.java
@@ -15,7 +15,10 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @RequiredArgsConstructor
@@ -33,13 +36,15 @@ public class SecurityWebConfig {
                 .securityMatcher(request -> !request.getServletPath().matches("^/api/v\\d+/.*$"))
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // 기본적으로 CSRF 보호 활성화
-
+                        .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
                 )
                 .headers(headers -> headers
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)) // Frame Options 비활성화
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/restaurant/**", "/evaluation/**", "/user/myPage", "/community/write","/api/post/**","/api/comment/**", "/admin/**").authenticated()
                         .anyRequest().permitAll()) // 모든 요청 허용
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/user/login")))
                 .oauth2Login(oauth2 -> oauth2
                         .loginPage("/user/login")
                         .failureUrl("/user/login?error")

--- a/src/main/java/com/kustaurant/kustaurant/global/config/security/roleHierarchyConfig.java
+++ b/src/main/java/com/kustaurant/kustaurant/global/config/security/roleHierarchyConfig.java
@@ -16,7 +16,10 @@ public class roleHierarchyConfig {
     @Bean
     public RoleHierarchy roleHierarchy() {
         RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
-        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");
+        roleHierarchy.setHierarchy(
+                "ROLE_ADMIN > ROLE_USER\n" +
+                "ROLE_USER  > ROLE_GUEST"
+        );
         return roleHierarchy;
     }
 }

--- a/src/main/java/com/kustaurant/kustaurant/global/exception/advice/GlobalExceptionWebHandler.java
+++ b/src/main/java/com/kustaurant/kustaurant/global/exception/advice/GlobalExceptionWebHandler.java
@@ -2,8 +2,11 @@ package com.kustaurant.kustaurant.global.exception.advice;
 
 import com.kustaurant.kustaurant.global.exception.exception.business.DataNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -22,6 +25,16 @@ public class GlobalExceptionWebHandler {
         log.error("[DataNotFoundException] {} {}: {}", req.getMethod(), req.getRequestURI(), e.getMessage(), e);
         model.addAttribute("message", "존재하지 않습니다.");
         return "error/not_found";
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public void handleAccessDeniedException(
+            AccessDeniedException e,
+            HttpServletRequest req,
+            HttpServletResponse res
+    ) throws IOException {
+        log.error("[AccessDeniedException] {} {}: {}", req.getMethod(), req.getRequestURI(), e.getMessage(), e);
+        res.sendRedirect(req.getContextPath() + "/user/login");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/application/constants/RestaurantConstants.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/application/constants/RestaurantConstants.java
@@ -1,5 +1,6 @@
 package com.kustaurant.kustaurant.restaurant.application.constants;
 
+import com.kustaurant.kustaurant.user.domain.User;
 import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -17,6 +18,22 @@ public abstract class RestaurantConstants {
         if (UserEntity.getEvaluationList().size() > 60) {
             return "https://kustaurant.s3.ap-northeast-2.amazonaws.com/common/level3icon" + (isIOS ? ".svg" : ".png");
         } else if (UserEntity.getEvaluationList().size() > 30) {
+            return "https://kustaurant.s3.ap-northeast-2.amazonaws.com/common/level2icon" + (isIOS ? ".svg" : ".png");
+        } else {
+            return "https://kustaurant.s3.ap-northeast-2.amazonaws.com/common/level1icon" + (isIOS ? ".svg" : ".png");
+        }
+    }
+
+    public static String getIconImgUrl(User user, String userAgent) {
+        if (user == null) {
+            return null;
+        }
+
+        boolean isIOS = isIOS(userAgent);
+
+        if (user.getEvaluationCount() > 60) {
+            return "https://kustaurant.s3.ap-northeast-2.amazonaws.com/common/level3icon" + (isIOS ? ".svg" : ".png");
+        } else if (user.getEvaluationCount() > 30) {
             return "https://kustaurant.s3.ap-northeast-2.amazonaws.com/common/level2icon" + (isIOS ? ".svg" : ".png");
         } else {
             return "https://kustaurant.s3.ap-northeast-2.amazonaws.com/common/level1icon" + (isIOS ? ".svg" : ".png");

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/application/service/command/RestaurantFavoriteService.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/application/service/command/RestaurantFavoriteService.java
@@ -1,9 +1,7 @@
 package com.kustaurant.kustaurant.restaurant.application.service.command;
 
-import com.kustaurant.kustaurant.restaurant.domain.Restaurant;
 import com.kustaurant.kustaurant.restaurant.domain.RestaurantFavorite;
 import com.kustaurant.kustaurant.restaurant.application.service.command.port.RestaurantFavoriteRepository;
-import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import com.kustaurant.kustaurant.global.exception.exception.business.DataNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,24 +22,24 @@ public class RestaurantFavoriteService {
     }
 
     // 유저의 즐겨찾기 식당 리스트를 반환
-    public List<Restaurant> getFavoriteRestaurantDtoList(Integer userId) {
+    public List<Integer> getFavoriteRestaurantIdList(Integer userId) {
         List<RestaurantFavorite> favorites = restaurantFavoriteRepository.findByUser(userId);
 
         return favorites.stream()
-                .map(RestaurantFavorite::getRestaurant)
+                .map(RestaurantFavorite::getRestaurantId)
                 .toList();
     }
 
     // 즐겨찾기 토글
     @Transactional
-    public boolean toggleFavorite(UserEntity user, Restaurant restaurant) {
+    public boolean toggleFavorite(Integer userId, Integer restaurantId) {
         RestaurantFavorite favorite;
         try {
             // 즐겨찾기 정보 조회
-            favorite = restaurantFavoriteRepository.findByUserIdAndRestaurantId(user.getUserId(), restaurant.getRestaurantId());
+            favorite = restaurantFavoriteRepository.findByUserIdAndRestaurantId(userId, restaurantId);
         } catch (DataNotFoundException e) {
             // 즐겨찾기가 안 되어 있는 경우
-            addFavorite(user, restaurant);
+            addFavorite(userId, restaurantId);
             return true;
         }
         // 즐겨찾기가 되어 있던 경우
@@ -49,14 +47,9 @@ public class RestaurantFavoriteService {
         return false;
     }
 
-    public void addFavorite(UserEntity user, Restaurant restaurant) {
+    public void addFavorite(Integer userId, Integer restaurantId) {
         restaurantFavoriteRepository.save(
-                RestaurantFavorite.builder()
-                .user(user.toModel())
-                .restaurant(restaurant)
-                .status("ACTIVE")
-                .createdAt(LocalDateTime.now())
-                .build()
+                RestaurantFavorite.create(userId, restaurantId)
         );
     }
 

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/application/service/command/port/RestaurantRepository.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/application/service/command/port/RestaurantRepository.java
@@ -15,6 +15,8 @@ public interface RestaurantRepository {
 
     Restaurant save(Restaurant restaurant);
 
+    Restaurant getReference(Integer id);
+
     // TODO: need to delete everything below this
     List<RestaurantEntity> findAll();
     List<RestaurantEntity> findByStatus(String status);

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/application/service/query/RestaurantHomeService.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/application/service/query/RestaurantHomeService.java
@@ -1,5 +1,6 @@
 package com.kustaurant.kustaurant.restaurant.application.service.query;
 
+import com.kustaurant.kustaurant.restaurant.application.service.command.port.RestaurantRepository;
 import com.kustaurant.kustaurant.restaurant.application.service.query.dto.RestaurantTierDTO;
 import com.kustaurant.kustaurant.restaurant.infrastructure.spec.RestaurantChartSpec;
 import com.kustaurant.kustaurant.restaurant.application.service.query.port.RestaurantQueryRepository;
@@ -19,6 +20,7 @@ public class RestaurantHomeService {
     private final int RECOMMENDATION_SIZE = 15;
 
     private final RestaurantQueryRepository restaurantQueryRepository;
+    private final RestaurantRepository restaurantRepository;
     private final RestaurantFavoriteService restaurantFavoriteService;
 
     private Random rand = new Random();
@@ -59,10 +61,12 @@ public class RestaurantHomeService {
 
     public String getFavoriteCuisine(Integer userId) {
         // 1. 즐겨찾기한 식당을 가져옵니다.
-        List<Restaurant> favoriteRestaurants = restaurantFavoriteService.getFavoriteRestaurantDtoList(userId);
+        List<Integer> favoriteRestaurants = restaurantFavoriteService.getFavoriteRestaurantIdList(userId);
 
         // 2. 식당들의 카테고리를 수집하여 가장 많이 즐겨찾기한 카테고리를 찾습니다.
         Map<String, Long> cuisineFrequencyMap = favoriteRestaurants.stream()
+                .map(restaurantRepository::getById)
+                .filter(r -> Objects.equals(r.getStatus(), "ACTIVE"))
                 .collect(Collectors.groupingBy(Restaurant::getRestaurantCuisine, Collectors.counting()));
 
         // 3. 가장 많이 즐겨찾기된 카테고리 찾기

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/domain/RestaurantFavorite.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/domain/RestaurantFavorite.java
@@ -12,17 +12,26 @@ import java.time.LocalDateTime;
 public class RestaurantFavorite {
 
     private Integer favoriteId;
-    User user;
-    Restaurant restaurant;
+    private Integer userId;
+    private Integer restaurantId;
     private String status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    public static RestaurantFavorite create(Integer userId, Integer restaurantId) {
+        return RestaurantFavorite.builder()
+                .userId(userId)
+                .restaurantId(restaurantId)
+                .status("ACTIVE")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
     public static RestaurantFavorite from(RestaurantFavoriteEntity entity) {
         return RestaurantFavorite.builder()
                 .favoriteId(entity.getFavoriteId())
-                .user(User.from(entity.getUser()))
-                .restaurant(Restaurant.from(entity.getRestaurant()))
+                .userId(entity.getUser().getUserId())
+                .restaurantId(entity.getRestaurant().getRestaurantId())
                 .status(entity.getStatus())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/entity/RestaurantFavoriteEntity.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/entity/RestaurantFavoriteEntity.java
@@ -1,7 +1,9 @@
 package com.kustaurant.kustaurant.restaurant.infrastructure.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.kustaurant.kustaurant.restaurant.domain.Restaurant;
 import com.kustaurant.kustaurant.restaurant.domain.RestaurantFavorite;
+import com.kustaurant.kustaurant.user.domain.User;
 import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -63,23 +65,23 @@ public class RestaurantFavoriteEntity {
     public RestaurantFavorite toDomain() {
         return RestaurantFavorite.builder()
                 .favoriteId(favoriteId)
-                .user(user.toModel())
-                .restaurant(restaurant.toDomain())
+                .userId(user.getUserId())
+                .restaurantId(restaurant.getRestaurantId())
                 .status(status)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();
     }
 
-    public static RestaurantFavoriteEntity fromDomain(RestaurantFavorite domain) {
+    public static RestaurantFavoriteEntity fromDomain(RestaurantFavorite domain, User user, Restaurant restaurant) {
         if (domain == null) {
             return null;
         }
 
         RestaurantFavoriteEntity entity = new RestaurantFavoriteEntity();
         entity.favoriteId = domain.getFavoriteId();
-        entity.user = UserEntity.from(domain.getUser());
-        entity.restaurant = RestaurantEntity.fromDomain(domain.getRestaurant());
+        entity.user = UserEntity.from(user);
+        entity.restaurant = RestaurantEntity.fromDomain(restaurant);
         entity.status = domain.getStatus();
         entity.createdAt = domain.getCreatedAt();
         entity.updatedAt = domain.getUpdatedAt();

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/repository/RestaurantFavoriteJpaRepository.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/repository/RestaurantFavoriteJpaRepository.java
@@ -15,7 +15,7 @@ public interface RestaurantFavoriteJpaRepository extends JpaRepository<Restauran
 
     @Query("""
         SELECT rf FROM RestaurantFavoriteEntity rf
-        WHERE rf.user.id = :userId
+        WHERE rf.user.userId = :userId
         ORDER BY rf.createdAt DESC""")
     List<RestaurantFavoriteEntity> findSortedFavoritesByUserIdDesc(@Param("userId") Integer userId);
 

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/repository/RestaurantFavoriteRepositoryImpl.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/repository/RestaurantFavoriteRepositoryImpl.java
@@ -3,11 +3,14 @@ package com.kustaurant.kustaurant.restaurant.infrastructure.repository;
 import static com.kustaurant.kustaurant.global.exception.ErrorCode.*;
 
 import com.kustaurant.kustaurant.global.exception.ErrorCode;
+import com.kustaurant.kustaurant.restaurant.application.service.command.port.RestaurantRepository;
 import com.kustaurant.kustaurant.restaurant.domain.RestaurantFavorite;
 import com.kustaurant.kustaurant.restaurant.infrastructure.entity.RestaurantFavoriteEntity;
 import com.kustaurant.kustaurant.restaurant.application.service.command.port.RestaurantFavoriteRepository;
 import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import com.kustaurant.kustaurant.global.exception.exception.business.DataNotFoundException;
+import com.kustaurant.kustaurant.user.service.port.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +22,8 @@ import java.util.List;
 public class RestaurantFavoriteRepositoryImpl implements RestaurantFavoriteRepository {
 
     private final RestaurantFavoriteJpaRepository jpaRepository;
+    private final UserRepository userRepository;
+    private final RestaurantRepository restaurantRepository;
 
     @Override
     public RestaurantFavorite findByUserIdAndRestaurantId(Integer userId, Integer restaurantId) {
@@ -49,13 +54,21 @@ public class RestaurantFavoriteRepositoryImpl implements RestaurantFavoriteRepos
     @Override
     @Transactional
     public RestaurantFavorite save(RestaurantFavorite restaurantFavorite) {
-        return jpaRepository.save(RestaurantFavoriteEntity.fromDomain(restaurantFavorite)).toDomain();
+        return jpaRepository.save(RestaurantFavoriteEntity.fromDomain(
+                restaurantFavorite,
+                userRepository.getReference(restaurantFavorite.getUserId()),
+                restaurantRepository.getReference(restaurantFavorite.getRestaurantId())
+        )).toDomain();
     }
 
     @Override
     @Transactional
     public void delete(RestaurantFavorite restaurantFavorite) {
-        jpaRepository.delete(RestaurantFavoriteEntity.fromDomain(restaurantFavorite));
+        jpaRepository.delete(RestaurantFavoriteEntity.fromDomain(
+                restaurantFavorite,
+                userRepository.getReference(restaurantFavorite.getUserId()),
+                restaurantRepository.getReference(restaurantFavorite.getRestaurantId())
+        ));
     }
 
     @Override

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/infrastructure/repository/RestaurantRepositoryImpl.java
@@ -79,6 +79,11 @@ public class RestaurantRepositoryImpl implements RestaurantQueryRepository, Rest
     }
 
     @Override
+    public Restaurant getReference(Integer id) {
+        return jpaRepository.getReferenceById(id).toDomain();
+    }
+
+    @Override
     public List<RestaurantEntity> findAll() {
         return List.of();
     }

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/api/RestaurantApiController.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/api/RestaurantApiController.java
@@ -126,12 +126,8 @@ public class RestaurantApiController {
             @PathVariable Integer restaurantId,
             @Parameter(hidden = true) @JwtToken Integer userId
     ) {
-        // 유저 가져오기
-        UserEntity UserEntity = userService.findUserById(userId);
-        // 식당 가져오기
-        Restaurant restaurant = restaurantService.getActiveDomain(restaurantId);
         // 즐겨찾기 로직
-        boolean result = restaurantFavoriteService.toggleFavorite(UserEntity, restaurant);
+        boolean result = restaurantFavoriteService.toggleFavorite(userId, restaurantId);
         // 즐겨찾기 이후 결과(즐겨찾기가 해제됐는지, 추가됐는지와 해당 식당의 즐겨찾기 개수)를 반환
         return ResponseEntity.ok(result);
     }
@@ -155,12 +151,10 @@ public class RestaurantApiController {
             @PathVariable Integer restaurantId,
             @Parameter(hidden = true) @JwtToken Integer userId
     ) {
-        // 유저 가져오기
-        UserEntity UserEntity = userService.findUserById(userId);
+        // 즐겨찾기 로직
+        boolean result = restaurantFavoriteService.toggleFavorite(userId, restaurantId);
         // 식당 가져오기
         Restaurant restaurant = restaurantService.getActiveDomain(restaurantId);
-        // 즐겨찾기 로직
-        boolean result = restaurantFavoriteService.toggleFavorite(UserEntity, restaurant);
         // 즐겨찾기 이후 결과(즐겨찾기가 해제됐는지, 추가됐는지와 해당 식당의 즐겨찾기 개수)를 반환
         return ResponseEntity.ok(new FavoriteResponseDTO(result, restaurant.getFavoriteCount()));
     }

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/web/RestaurantWebController.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/web/RestaurantWebController.java
@@ -1,11 +1,13 @@
 package com.kustaurant.kustaurant.restaurant.presentation.web;
 
+import com.kustaurant.kustaurant.global.auth.argumentResolver.JwtToken;
 import com.kustaurant.kustaurant.restaurant.domain.Restaurant;
 import com.kustaurant.kustaurant.restaurant.application.service.command.RestaurantFavoriteService;
 import com.kustaurant.kustaurant.restaurant.application.service.command.RestaurantService;
 
 import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
 import com.kustaurant.kustaurant.global.auth.session.CustomOAuth2UserService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -32,16 +34,14 @@ public class RestaurantWebController {
     public String restaurant(
             Model model,
             @PathVariable Integer restaurantId,
-            Principal principal
+            @Parameter(hidden = true) @JwtToken Integer userId
     ) {
         model.addAttribute("initialDisplayMenuCount", initialDisplayMenuCount);
-        // 유저
-        UserEntity user = principal == null ? null : customOAuth2UserService.getUser(principal.getName());
         // 식당 정보
-        RestaurantDetailWebDto restaurantDetailWebDto = restaurantWebService.getRestaurantWebDetails(user, restaurantId);
+        RestaurantDetailWebDto restaurantDetailWebDto = restaurantWebService.getRestaurantWebDetails(userId, restaurantId);
         model.addAttribute("restaurantDto", restaurantDetailWebDto);
         String evaluationButton =
-                (user != null && restaurantDetailWebDto.getRestaurantDetail().getIsEvaluated()) ? "다시 평가하기" : " 평가하기";
+                (userId != null && restaurantDetailWebDto.getRestaurantDetail().getIsEvaluated()) ? "다시 평가하기" : " 평가하기";
         model.addAttribute("evaluationButton", evaluationButton);
         // 메뉴 정보
         model.addAttribute("menus", restaurantDetailWebDto.getRestaurantDetail().getRestaurantMenuList());

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/web/RestaurantWebController.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/web/RestaurantWebController.java
@@ -1,14 +1,11 @@
 package com.kustaurant.kustaurant.restaurant.presentation.web;
 
-import com.kustaurant.kustaurant.global.auth.argumentResolver.JwtToken;
-import com.kustaurant.kustaurant.restaurant.domain.Restaurant;
+import com.kustaurant.kustaurant.global.auth.argumentResolver.AuthUser;
+import com.kustaurant.kustaurant.global.auth.argumentResolver.AuthUserInfo;
 import com.kustaurant.kustaurant.restaurant.application.service.command.RestaurantFavoriteService;
-import com.kustaurant.kustaurant.restaurant.application.service.command.RestaurantService;
 
-import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
-import com.kustaurant.kustaurant.global.auth.session.CustomOAuth2UserService;
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,14 +13,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
-
+@Slf4j
 @RequiredArgsConstructor
 @Controller
 public class RestaurantWebController {
 
-    private final CustomOAuth2UserService customOAuth2UserService;
-    private final RestaurantService restaurantService;
     private final RestaurantWebService restaurantWebService;
     private final RestaurantFavoriteService restaurantFavoriteService;
 
@@ -34,14 +28,14 @@ public class RestaurantWebController {
     public String restaurant(
             Model model,
             @PathVariable Integer restaurantId,
-            @Parameter(hidden = true) @JwtToken Integer userId
+            @AuthUser AuthUserInfo user
     ) {
         model.addAttribute("initialDisplayMenuCount", initialDisplayMenuCount);
         // 식당 정보
-        RestaurantDetailWebDto restaurantDetailWebDto = restaurantWebService.getRestaurantWebDetails(userId, restaurantId);
+        RestaurantDetailWebDto restaurantDetailWebDto = restaurantWebService.getRestaurantWebDetails(user.id(), restaurantId);
         model.addAttribute("restaurantDto", restaurantDetailWebDto);
         String evaluationButton =
-                (userId != null && restaurantDetailWebDto.getRestaurantDetail().getIsEvaluated()) ? "다시 평가하기" : " 평가하기";
+                (user.id() != null && restaurantDetailWebDto.getRestaurantDetail().getIsEvaluated()) ? "다시 평가하기" : " 평가하기";
         model.addAttribute("evaluationButton", evaluationButton);
         // 메뉴 정보
         model.addAttribute("menus", restaurantDetailWebDto.getRestaurantDetail().getRestaurantMenuList());
@@ -56,11 +50,9 @@ public class RestaurantWebController {
     @PostMapping("/web/api/restaurants/{restaurantId}/favorite/toggle")
     public ResponseEntity<Boolean> toggleFavorite(
             @PathVariable Integer restaurantId,
-            Principal principal
+            @AuthUser AuthUserInfo user
     ) {
-        UserEntity user = customOAuth2UserService.getUser(principal.getName());
-        Restaurant restaurant = restaurantService.getActiveDomain(restaurantId);
-        return ResponseEntity.ok(restaurantFavoriteService.toggleFavorite(user, restaurant));
+        return ResponseEntity.ok(restaurantFavoriteService.toggleFavorite(user.id(), restaurantId));
     }
 
 }

--- a/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/web/RestaurantWebService.java
+++ b/src/main/java/com/kustaurant/kustaurant/restaurant/presentation/web/RestaurantWebService.java
@@ -32,12 +32,10 @@ public class RestaurantWebService {
     private final RestaurantService restaurantService;
     private final RestaurantCommentService restaurantCommentService;
 
-    public RestaurantDetailWebDto getRestaurantWebDetails(UserEntity user, Integer restaurantId) {
-        Integer userId = user == null ? null : user.getUserId();
+    public RestaurantDetailWebDto getRestaurantWebDetails(Integer userId, Integer restaurantId) {
         RestaurantDetailDTO restaurantDetailDto = restaurantService.getActiveRestaurantDetailDto(restaurantId, userId, "web");
         Restaurant restaurant = restaurantService.getActiveDomain(restaurantId);
-        // TODO: 이거도 userId 사용하게 바꿔야됨.
-        List<RestaurantCommentDTO> comments = restaurantCommentService.getRestaurantCommentList(restaurantId, user, true, "web");
+        List<RestaurantCommentDTO> comments = restaurantCommentService.getRestaurantCommentList(restaurantId, userId, true, "web");
 
         return new RestaurantDetailWebDto(
                 restaurantDetailDto,

--- a/src/main/java/com/kustaurant/kustaurant/user/domain/enums/UserRole.java
+++ b/src/main/java/com/kustaurant/kustaurant/user/domain/enums/UserRole.java
@@ -4,8 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum UserRole {
-    ADMIN("ROLE_ADMIN"),
+    GUEST("ROLE_GUEST"),
     USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
     OWNER("ROLE_OWNER");
 
     private final String value;

--- a/src/main/java/com/kustaurant/kustaurant/user/infrastructure/UserEntity.java
+++ b/src/main/java/com/kustaurant/kustaurant/user/infrastructure/UserEntity.java
@@ -104,6 +104,7 @@ public class UserEntity {
 
     @Builder
     public UserEntity(
+            Integer userId,
             String providerId,
             String loginApi,
             String email,
@@ -113,6 +114,7 @@ public class UserEntity {
             UserStatus status,
             LocalDateTime createdAt
     ) {
+        this.userId = userId;
         this.providerId = providerId;
         this.loginApi = loginApi;
         this.email = email;
@@ -143,6 +145,7 @@ public class UserEntity {
 
     public static UserEntity from(User user) {
         return UserEntity.builder()
+                .userId(user.getId())
                 .providerId(user.getProviderId())
                 .loginApi(user.getLoginApi())
                 .email(user.getEmail())

--- a/src/main/java/com/kustaurant/kustaurant/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/kustaurant/kustaurant/user/infrastructure/UserRepositoryImpl.java
@@ -73,6 +73,11 @@ public class UserRepositoryImpl implements UserRepository {
                 ));
     }
 
+    @Override
+    public User getReference(Integer userId) {
+        return userJpaRepository.getReferenceById((long) userId).toModel();
+    }
+
 
     public Optional<UserEntity> findEntityById(Integer id) {
         return userJpaRepository.findByUserId(id);

--- a/src/main/java/com/kustaurant/kustaurant/user/service/port/UserRepository.java
+++ b/src/main/java/com/kustaurant/kustaurant/user/service/port/UserRepository.java
@@ -21,4 +21,5 @@ public interface UserRepository {
 
     Map<Integer, UserDTO> getUserDTOMapByIds(List<Integer> ids);
 
+    User getReference(Integer userId);
 }

--- a/src/main/java/com/kustaurant/kustaurant/web/discovery/RestaurantTierWebController.java
+++ b/src/main/java/com/kustaurant/kustaurant/web/discovery/RestaurantTierWebController.java
@@ -4,6 +4,7 @@ package com.kustaurant.kustaurant.web.discovery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kustaurant.kustaurant.evaluation.service.port.EvaluationRepository;
+import com.kustaurant.kustaurant.global.auth.argumentResolver.JwtToken;
 import com.kustaurant.kustaurant.restaurant.application.service.query.dto.RestaurantTierDTO;
 import com.kustaurant.kustaurant.restaurant.application.service.query.RestaurantChartService;
 import com.kustaurant.kustaurant.user.infrastructure.UserEntity;
@@ -11,7 +12,9 @@ import com.kustaurant.kustaurant.restaurant.presentation.argument_resolver.Cuisi
 import com.kustaurant.kustaurant.restaurant.presentation.argument_resolver.LocationList;
 import com.kustaurant.kustaurant.restaurant.presentation.argument_resolver.SituationList;
 import com.kustaurant.kustaurant.global.auth.session.CustomOAuth2UserService;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -75,7 +78,7 @@ public class RestaurantTierWebController {
             @CuisineList List<String> cuisines,
             @SituationList List<Integer> situations,
             @LocationList List<String> locations,
-            Principal principal,
+            @Parameter(hidden = true) @JwtToken Integer userId,
             HttpServletRequest request
     ) {
         // page를 0부터 시작하도록 처리
@@ -84,11 +87,9 @@ public class RestaurantTierWebController {
         } else {
             page--;
         }
-        // User 처리
-        UserEntity user = customOAuth2UserService.getUserByPrincipal(principal);
-        Integer userId = user == null ? null : user.getUserId();
         // DB 조회
-        List<RestaurantTierDTO> tierRestaurants = restaurantChartService.findByConditions(cuisines, situations, locations, null, true, userId);
+        List<RestaurantTierDTO> tierRestaurants = restaurantChartService.findByConditions(
+                cuisines, situations, locations, null, true, userId);
 
         Pageable pageable = PageRequest.of(page, tierPageSize);
 

--- a/src/main/resources/static/js/restaurantScript.js
+++ b/src/main/resources/static/js/restaurantScript.js
@@ -47,6 +47,10 @@ document.getElementById('favoriteImg').addEventListener('click', function() {
 function toggleFavoriteRequest() {
     fetch(window.location.origin + "/web/api" + window.location.pathname + "/favorite/toggle", {
         method: 'POST',
+        headers: {
+            "Content-Type": "application/json",
+            [csrfHeader]: csrfToken
+        }
     })
         .then(response => {
             if (response.redirected) {
@@ -167,31 +171,31 @@ if (unfoldButton) {
 }
 
 // 네이버 지도 펼쳤다 접기
-document.getElementById('mapUnfoldButton').addEventListener('click', function() {
-    const thisText = this.textContent;
-    const mapDiv = document.getElementById('map');
-    const mapContainer = document.getElementById('mapContainer');
-    const width = parseFloat(getComputedStyle(this).width);
-
-    if (thisText === '펼치기') {
-        this.textContent = '접기';
-        let newHeight = width * 0.6;
-        if (newHeight < 400) {
-            newHeight = 400;
-        }
-        resize(width, newHeight);
-        // 지도가 가장 위로 오도록 화면 스크롤
-        document.getElementById('mapTopDiv').scrollIntoView({ behavior: 'smooth', block: 'start' });
-        //window.scrollBy(0, -110);
-    } else {
-        this.textContent = '펼치기';
-        resize(width, 150);
-    }
-});
-function resize(width, height){
-    var Size = new naver.maps.Size(width, height);
-    map.setSize(Size);
-}
+// document.getElementById('mapUnfoldButton').addEventListener('click', function() {
+//     const thisText = this.textContent;
+//     const mapDiv = document.getElementById('map');
+//     const mapContainer = document.getElementById('mapContainer');
+//     const width = parseFloat(getComputedStyle(this).width);
+//
+//     if (thisText === '펼치기') {
+//         this.textContent = '접기';
+//         let newHeight = width * 0.6;
+//         if (newHeight < 400) {
+//             newHeight = 400;
+//         }
+//         resize(width, newHeight);
+//         // 지도가 가장 위로 오도록 화면 스크롤
+//         document.getElementById('mapTopDiv').scrollIntoView({ behavior: 'smooth', block: 'start' });
+//         //window.scrollBy(0, -110);
+//     } else {
+//         this.textContent = '펼치기';
+//         resize(width, 150);
+//     }
+// });
+// function resize(width, height){
+//     var Size = new naver.maps.Size(width, height);
+//     map.setSize(Size);
+// }
 
 // 댓글 입력 창 글자 제한
 // const commentTextArea = document.getElementById('commentInput');
@@ -206,8 +210,17 @@ function resize(width, height){
 //     }
 // });
 
+// csrf 토큰 읽어오기
+// CSRF 토큰 가져오기
+const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+
 // 댓글 인기순, 최신순 토글 초기화
-let activeButton = document.getElementById('button1');
+const btn1 = document.getElementById('button1');
+const btn2 = document.getElementById('button2');
+let activeButton = btn1;
+btn1.addEventListener('click', () => toggleButton(1));
+btn2.addEventListener('click', () => toggleButton(2));
 // 댓글 인기순, 최신순 토글 함수
 function toggleButton(buttonNumber) {
     const commentsUl = document.getElementById('commentList');
@@ -254,7 +267,8 @@ function sendComment() {
     fetch(apiUrl, {
         method: "POST",
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            [csrfHeader]: csrfToken
         },
         body: JSON.stringify({
             commentBody: commentBody,
@@ -272,8 +286,8 @@ function sendComment() {
                 } else if (response.status === 400) {
                     // 메시지가 빈 경우
                     commentInput.value = '';
-                    return response.text().then(errorMessege => {
-                        alert(errorMessege);
+                    return response.text().then(errorMessage => {
+                        alert(errorMessage);
                     })
                 } else {
                     throw new Error(`HTTP error! Status: ${response.status}`);
@@ -290,10 +304,12 @@ function commentLike(button) {
     const commentId = button.getAttribute("data-id");
     const parentCommentId = button.getAttribute("data-parent-id");
     const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}/like`;
+
     fetch(apiUrl, {
-        method: "GET",
+        method: "POST",
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            [csrfHeader]: csrfToken
         },
     })
         .then(response => {
@@ -315,10 +331,12 @@ function commentDislike(button) {
     const commentId = button.getAttribute("data-id");
     const parentCommentId = button.getAttribute("data-parent-id");
     const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}/dislike`;
+
     fetch(apiUrl, {
-        method: "GET",
+        method: "POST",
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            [csrfHeader]: csrfToken
         },
     })
         .then(response => {
@@ -359,6 +377,7 @@ function deleteComment(deleteButton) {
         const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}`;
         fetch(apiUrl, {
             method: "DELETE",
+            [csrfHeader]: csrfToken
         })
             .then(response => {
                 if (!response.ok) {

--- a/src/main/resources/static/js/restaurantScript.js
+++ b/src/main/resources/static/js/restaurantScript.js
@@ -213,7 +213,7 @@ function toggleButton(buttonNumber) {
     const commentsUl = document.getElementById('commentList');
     const currentButton = document.getElementById(`button${buttonNumber}`);
     const queryParameter = buttonNumber === 1 ? 'POPULAR' : 'LATEST';
-    const apiUrl = "/api" + window.location.pathname + "/comments?sort=" + queryParameter;
+    const apiUrl = "/web/api" + window.location.pathname + "/comments?sort=" + queryParameter;
     fetch(apiUrl)
         .then(response => {
             if (!response.ok) {
@@ -243,7 +243,7 @@ function toggleButton(buttonNumber) {
 
 // 댓글 달기 요청
 function sendComment() {
-    const apiUrl = window.location.origin + "/api" + window.location.pathname + "/comments";
+    const apiUrl = window.location.origin + "/web/api" + window.location.pathname + "/comments";
     const currentUrl = window.location.href;
     const commentInput = document.getElementById('commentInput');
     const commentBody = commentInput.value.trim();
@@ -289,7 +289,7 @@ function sendComment() {
 function commentLike(button) {
     const commentId = button.getAttribute("data-id");
     const parentCommentId = button.getAttribute("data-parent-id");
-    const apiUrl = window.location.origin + `/api/restaurants/comments/${commentId}/like`;
+    const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}/like`;
     fetch(apiUrl, {
         method: "GET",
         headers: {
@@ -314,7 +314,7 @@ function commentLike(button) {
 function commentDislike(button) {
     const commentId = button.getAttribute("data-id");
     const parentCommentId = button.getAttribute("data-parent-id");
-    const apiUrl = window.location.origin + `/api/restaurants/comments/${commentId}/dislike`;
+    const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}/dislike`;
     fetch(apiUrl, {
         method: "GET",
         headers: {
@@ -337,7 +337,7 @@ function commentDislike(button) {
 }
 // 댓글 하나 html 교체
 function changeCommentHtml(commentId, commentLi) {
-    const apiUrl = window.location.origin + `/api/restaurants/comments/${commentId}`;
+    const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}`;
     fetch(apiUrl, {
         method: "GET",
     })
@@ -356,7 +356,7 @@ function deleteComment(deleteButton) {
     var deleteAgreeButton = document.getElementById('deleteAgreeButton');
 
     deleteAgreeButton.onclick = function() {
-        const apiUrl = window.location.origin + `/api/restaurants/comments/${commentId}`;
+        const apiUrl = window.location.origin + `/web/api/restaurants/comments/${commentId}`;
         fetch(apiUrl, {
             method: "DELETE",
         })

--- a/src/main/resources/templates/restaurant.html
+++ b/src/main/resources/templates/restaurant.html
@@ -134,11 +134,11 @@
         </div>
         <div id="menuUnfoldButton" class="unfold-button" th:if="${#lists.size(restaurantDto.restaurantDetail.restaurantMenuList) > 3}">펼치기</div>
     </div>
-    <div id="mapContainer" class="inner-container">
-        <div id="mapTopDiv" style="height:110px; width:100%; position: absolute; top: -110px; left: 0; visibility: hidden;"></div>
-        <div id="map"></div>
-        <div id="mapUnfoldButton" class="unfold-button">펼치기</div>
-    </div>
+<!--    <div id="mapContainer" class="inner-container">-->
+<!--        <div id="mapTopDiv" style="height:110px; width:100%; position: absolute; top: -110px; left: 0; visibility: hidden;"></div>-->
+<!--        <div id="map"></div>-->
+<!--        <div id="mapUnfoldButton" class="unfold-button">펼치기</div>-->
+<!--    </div>-->
 
     <a class="inner-container evaluation-button button" id="evaluationButton"
        th:href="@{/evaluation/{restuarantId}(restuarantId=${restaurantDto.restaurantDetail.restaurantId})}"
@@ -184,7 +184,7 @@
                             <span th:text="${restaurantComment.commentScore}"></span>
                         </div>
                         <div class="nick-date-div">
-                            <img class="icon" th:src="${restaurantComment.userEntity.getRankImg()}">
+                            <img class="icon" th:src="${restaurantComment.getCommentIconImgUrl()}">
                             <span class="nick-span" th:text="${restaurantComment.commentNickname}"></span>
                             <span class="date-span" th:text="${restaurantComment.commentTime}"></span>
                             <!-- Button trigger modal -->
@@ -217,7 +217,7 @@
                         </div>
                         <div class="body-div">
                             <div class="nick-date-div">
-                                <img th:src="${reply.user.getRankImg()}">
+                                <img th:src="${reply.getCommentIconImgUrl()}">
                                 <span class="nick-span" th:text="${reply.commentNickname}"></span>
                                 <span class="date-span" th:text="${reply.commentTime}"></span>
                                 <!-- Button trigger modal -->

--- a/src/main/resources/templates/restaurant.html
+++ b/src/main/resources/templates/restaurant.html
@@ -21,6 +21,9 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <title th:text="${'쿠스토랑 - ' + restaurantDto.restaurantDetail.getRestaurantName()}"></title>
     <meta charset="UTF-8"/>
+    <!--  csrf token  -->
+    <meta name="_csrf" th:content="${_csrf.token}" />
+    <meta name="_csrf_header" th:content="${_csrf.headerName}" />
 
     <!-- 아이콘 라이브러리-->
     <script src="https://kit.fontawesome.com/0c60714712.js" crossorigin="anonymous"></script>
@@ -45,7 +48,7 @@
         const restaurantMenus = /*[[${menus}]]*/ [];
         const initialDisplayMenuCount = /*[[${initialDisplayMenuCount}]]*/ [];
     </script>
-    <script src="/js/restaurantScript.js" defer></script>
+    <script type="text/javascript" src="/js/restaurantScript.js" defer></script>
     <script type="text/javascript" src="https://static.nid.naver.com/js/naverLogin_implicit-1.0.3.js"
             charset="utf-8"></script>
     <script src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=gifrujmoep"></script>
@@ -144,19 +147,11 @@
        th:href="@{/evaluation/{restuarantId}(restuarantId=${restaurantDto.restaurantDetail.restaurantId})}"
        th:text="${evaluationButton}"></a>
 
-    <!-- 댓글 쓰는 부분 : 기능 변경으로 삭제 -->
+    <!-- 댓글 정렬 -->
     <div class="comment-container">
-        <!--<div class="section-title">댓글</div>
-        <div class="input-container">
-            <div>
-                <textarea id="commentInput" placeholder="식당에 대한 댓글을 남겨주세요." spellcheck="false"></textarea>
-                <span id="commentAlert"></span>
-            </div>
-            <button class="button evaluation-button" onclick="sendComment()">등록</button>
-        </div>-->
         <div class="sort-toggle-buttons">
-            <button id="button1" class="active" onclick="toggleButton(1)">인기순</button>
-            <button id="button2" onclick="toggleButton(2)">최신순</button>
+            <button id="button1" class="active">인기순</button>
+            <button id="button2">최신순</button>
         </div>
     </div>
 

--- a/src/main/resources/templates/restaurantComment.html
+++ b/src/main/resources/templates/restaurantComment.html
@@ -18,7 +18,7 @@
             <span th:text="${restaurantComment.commentScore}"></span>
         </div>
         <div class="nick-date-div">
-            <img th:src="${restaurantComment.userEntity.getRankImg()}">
+            <img th:src="${restaurantComment.getCommentIconImgUrl()}">
             <span class="nick-span" th:text="${restaurantComment.commentNickname}"></span>
             <span class="date-span" th:text="${restaurantComment.commentTime}"></span>
             <!-- Button trigger modal -->
@@ -51,7 +51,7 @@
         </div>
         <div class="body-div">
             <div class="nick-date-div">
-                <img th:src="${reply.userEntity.getRankImg()}">
+                <img th:src="${reply.getCommentIconImgUrl()}">
                 <span class="nick-span" th:text="${reply.commentNickname}"></span>
                 <span class="date-span" th:text="${reply.commentTime}"></span>
                 <!-- Button trigger modal -->

--- a/src/main/resources/templates/restaurantComments.html
+++ b/src/main/resources/templates/restaurantComments.html
@@ -19,7 +19,7 @@
                 <span th:text="${restaurantComment.commentScore}"></span>
             </div>
             <div class="nick-date-div">
-                <img th:src="${restaurantComment.userEntity.getRankImg()}">
+                <img th:src="${restaurantComment.getCommentIconImgUrl()}">
                 <span class="nick-span" th:text="${restaurantComment.commentNickname}"></span>
                 <span class="date-span" th:text="${restaurantComment.commentTime}"></span>
                 <!-- Button trigger modal -->
@@ -52,7 +52,7 @@
             </div>
             <div class="body-div">
                 <div class="nick-date-div">
-                    <img th:src="${reply.userEntity.getRankImg()}">
+                    <img th:src="${reply.getCommentIconImgUrl()}">
                     <span class="nick-span" th:text="${reply.commentNickname}"></span>
                     <span class="date-span" th:text="${reply.commentTime}"></span>
                     <!-- Button trigger modal -->

--- a/src/test/java/com/kustaurant/kustaurant/mock/FakeUserRepository.java
+++ b/src/test/java/com/kustaurant/kustaurant/mock/FakeUserRepository.java
@@ -76,4 +76,9 @@ public class FakeUserRepository implements UserRepository {
     public Map<Integer, UserDTO> getUserDTOMapByIds(List<Integer> ids) {
         return Map.of();
     }
+
+    @Override
+    public User getReference(Integer userId) {
+        return getById(userId);
+    }
 }

--- a/src/test/java/com/kustaurant/kustaurant/restaurant/service/RestaurantFavoriteServiceTest.java
+++ b/src/test/java/com/kustaurant/kustaurant/restaurant/service/RestaurantFavoriteServiceTest.java
@@ -24,15 +24,17 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 즐겨찾기_추가() {
         // Given
+        Integer userId = 1;
+        Integer restaurantId = 2;
         UserEntity user = new UserEntity();
-        user.setUserId(1);
+        user.setUserId(userId);
         Restaurant restaurant = Restaurant.builder()
-                .restaurantId(1)
+                .restaurantId(restaurantId)
                 .restaurantName("곤칼")
                 .build();
 
         // When
-        favoriteService.addFavorite(user, restaurant);
+        favoriteService.addFavorite(userId, restaurantId);
 
         // Then
         assertThat(favoriteRepository.existsByUserAndRestaurant(user.getUserId(), restaurant.getRestaurantId()))
@@ -42,14 +44,16 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 즐겨찾기_삭제() {
         // Given
+        Integer userId = 1;
+        Integer restaurantId = 2;
         UserEntity user = new UserEntity();
-        user.setUserId(1);
+        user.setUserId(userId);
         Restaurant restaurant = Restaurant.builder()
-                .restaurantId(1)
+                .restaurantId(restaurantId)
                 .restaurantName("곤칼")
                 .build();
 
-        favoriteService.addFavorite(user, restaurant);
+        favoriteService.addFavorite(userId, restaurantId);
         RestaurantFavorite favorite = favoriteRepository.findByUserIdAndRestaurantId(user.getUserId(), restaurant.getRestaurantId());
 
         // When
@@ -63,15 +67,17 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 새로_즐겨찾기_추가하는_경우() {
         // Given
+        Integer userId = 1;
+        Integer restaurantId = 2;
         UserEntity user = new UserEntity();
-        user.setUserId(1);
+        user.setUserId(userId);
         Restaurant restaurant = Restaurant.builder()
-                .restaurantId(1)
+                .restaurantId(restaurantId)
                 .restaurantName("곤칼")
                 .build();
 
         // When
-        boolean result = favoriteService.toggleFavorite(user, restaurant);
+        boolean result = favoriteService.toggleFavorite(userId, restaurantId);
 
         // Then
         assertThat(result).isTrue();
@@ -82,18 +88,20 @@ class RestaurantFavoriteServiceTest {
     @Test
     void 이전에_즐겨찾기가_되어_있었던_경우() {
         // Given
+        Integer userId = 1;
+        Integer restaurantId = 2;
         UserEntity user = new UserEntity();
-        user.setUserId(1);
+        user.setUserId(userId);
         Restaurant restaurant = Restaurant.builder()
-                .restaurantId(1)
+                .restaurantId(restaurantId)
                 .restaurantName("곤칼")
                 .build();
 
         // 즐겨찾기 추가
-        favoriteService.addFavorite(user, restaurant);
+        favoriteService.addFavorite(userId, restaurantId);
 
         // When
-        boolean result = favoriteService.toggleFavorite(user, restaurant);
+        boolean result = favoriteService.toggleFavorite(userId, restaurantId);
 
         // Then
         assertThat(result).isFalse();


### PR DESCRIPTION
## 개요
1. 식당 상세화면에서 평가와 대댓글이 정상적으로 표시되지 않던 문제를 해결했습니다.
2. 식당 즐겨찾기 기능을 정상화했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경 사항
### 1 AuthUserArgumentResolver 수정
- **문제 상황**
    
    로그인 상태가 아닐 때 컨트롤러에서 `@AuthUser AuthUserInfo user`를 파라미터에서 받으면 예외 발생
    
- **기존 `AuthUserArgumentResolver`**
    
    ```java
    if (auth.getPrincipal() instanceof CustomOAuth2User oAuthUser) {        // 웹 세션
        userId = oAuthUser.getUserId();
    } else if (auth.getPrincipal() instanceof Integer uid) {                // 앱 JWT
        userId = uid;
    } else {
        throw new UnauthenticatedException(
                "지원하지 않는 principal 타입: " + auth.getPrincipal().getClass().getName());
    }
    ```
    
- **변경 후 `AuthUserArgumentResolver`**
    
    ```java
    if (auth.getPrincipal() instanceof CustomOAuth2User oAuthUser) {        // 웹 세션
        userId = oAuthUser.getUserId();
    } else if (auth.getPrincipal() instanceof Integer uid) {                // 앱 JWT
        userId = uid;
    } else if (auth.getPrincipal() instanceof String s && "anonymousUser".equals(s)) {
        return new AuthUserInfo(null, UserRole.GUEST);
    }else {
        throw new UnauthenticatedException(
                "지원하지 않는 principal 타입: " + auth.getPrincipal().getClass().getName());
    }
    ```
    
- **`UserRole` 추가**
    
    `*GUEST*("ROLE_GUEST")` 추가함
    
    ```java
    public enum UserRole {
        GUEST("ROLE_GUEST"),
        USER("ROLE_USER"),
        ADMIN("ROLE_ADMIN"),
        ...
    ```
    
- **Hierarchy 규칙 추가**
    
    ROLE_GUEST에 대한 규칙 추가함
    
    ```java
    @Bean
    public RoleHierarchy roleHierarchy() {
        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
        roleHierarchy.setHierarchy(
                "ROLE_ADMIN > ROLE_USER\n" + 
                "ROLE_USER  > ROLE_GUEST"
        );
        return roleHierarchy;
    }
    ```
    

### 2 식당 즐겨찾기 토글 코드 변경

- **문제 상황**
    
    `userId`와 `restaurantId` 만으로 즐겨찾기를 추가해야 하는데, 연관관계로 인해 `UserEntity`와 `RestaurantEntity`가 필요함.
    
- **프록시 객체를 통한 연관관계 엔티티 설정**
    
    식당 즐겨찾기 저장 시에 `RestaruantFavoriteEntity`에 `UserEntity`와 `RestaurantEntity`를 넣어줘야 Spring Data JPA의 `save` 함수를 통해 저장할 때 외래키가 설정이 됩니다.
    
    SQL 상으로는 id만 있어도 외래키를 설정할 수 있는데 DB에서 `UserEntity`와 `RestaurantEntity`를 조회하는 것은 지나친 것 같아서 방법을 찾아봤습니다. 찾다보니 `id`로 프록시 객체를 조회하는 기능이 있어서 이를 사용했습니다.
    
    - **`UserRepository`에서  프록시 객체 조회하기**
        
        ```java
        @Override
        public User getReference(Integer userId) {
            return userJpaRepository.getReferenceById((long) userId).toModel();
        }
        ```
        
    - **`RestaurantRepository`에서 프록시 객체 조회하기**
        
        ```java
        @Override
        public Restaurant getReference(Integer id) {
            return jpaRepository.getReferenceById(id).toDomain();
        }
        ```
        

### 3 csrf token 설정

- **문제 상황**
    
    csrf 설정이 추가됨에 따라 식당 상세 화면의 POST 요청이 403으로 반환되는 것을 확인했습니다.
    
- **POST 요청 헤더에 `XSRF-TOKEN` 추가**
    
    ```java
    headers: {
        "Content-Type": "application/json",
        [csrfHeader]: csrfToken
    }
    ```
    
    화면 렌더링 시 발급한 csrf 토큰을 POST 요청의 헤더에 추가해서 문제를 해결했습니다.