### PR TITLE
chore: Java 버전 21로 업그레이드 및 테스트 자동화 추가

### DIFF
--- a/.github/workflows/pre-test.yml
+++ b/.github/workflows/pre-test.yml
@@ -1,0 +1,89 @@
+name: 자동테스트
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  small-test:
+    name: 🧪 소형 테스트
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Gradle test (small only)
+        run: ./gradlew smallTest
+
+      - name: Publish Small Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: build/test-results/smallTest/TEST-*.xml
+          check_name: 🧪 소형 테스트 결과
+          check_run: false
+
+  #      - name: Publish Test Report
+  #        if: always()
+  #        uses: dorny/test-reporter@v1
+  #        with:
+  #          name: 🧪 소형 테스트 리포트
+  #          path: build/test-results/smallTest/*.xml
+  #          reporter: java-junit
+
+  middle-test:
+    name: 🚀 중형 테스트
+    runs-on: ubuntu-latest
+    env:
+      JWT_SECRET: thisIsA32ByteLengthSecretKeyForJWT!
+      JWT_ACCESS_TOKEN_EXPIRATION : 900
+      JWT_REFRESH_TOKEN_EXPIRATION : 604800
+      NAVER_CLIENT_ID : kustaurant
+      NAVER_CLIENT_SECRET : secreat
+      APPLE_CLIENT_ID : kustaurant
+      APPLE_PUBLIC_KEYS_URL : https://appleid.apple.com/auth/keys
+
+    services:
+      docker:
+        image: docker:24.0.2
+        options: >-
+          --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Gradle test (middle only)
+        run: ./gradlew middleTest
+
+      - name: Publish Middle Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: build/test-results/middleTest/TEST-*.xml
+          check_name: 🚀 중형 테스트 결과
+          check_run: false
+
+#      - name: Publish Test Report
+#        if: always()
+#        uses: dorny/test-reporter@v1
+#        with:
+#          name: 🚀 중형 테스트 리포트
+#          path: build/test-results/middleTest/*.xml
+#          reporter: java-junit

--- a/.github/workflows/pre-test.yml
+++ b/.github/workflows/pre-test.yml
@@ -31,7 +31,7 @@ jobs:
         if: always()
         with:
           files: build/test-results/smallTest/TEST-*.xml
-          check_name: 🧪 소형 테스트 결과
+          check_name: 🧪 소형(단위) 테스트 결과
           check_run: false
 
   #      - name: Publish Test Report
@@ -77,7 +77,7 @@ jobs:
         if: always()
         with:
           files: build/test-results/middleTest/TEST-*.xml
-          check_name: 🚀 중형 테스트 결과
+          check_name: 🚀 중형(통합) 테스트 결과
           check_run: false
 
 #      - name: Publish Test Report

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,6 @@ tasks.register('middleTest', Test) {
 	testClassesDirs = sourceSets.test.output.classesDirs
 	classpath = sourceSets.test.runtimeClasspath
 	shouldRunAfter test
-	reports.junitXml.destination = layout.buildDirectory.dir("test-results/integrationTest").get().asFile
-	reports.html.destination = layout.buildDirectory.dir("reports/tests/integrationTest").get().asFile
+	reports.junitXml.destination = layout.buildDirectory.dir("test-results/middleTest").get().asFile
+	reports.html.destination = layout.buildDirectory.dir("reports/tests/middleTest").get().asFile
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,10 @@ plugins {
 group = 'com.kustaurant'
 // 배포 버젼
 version = '0.1.0-SNAPSHOT'
-// 배포 자바 버젼
 java {
-	sourceCompatibility = '17'
-//	sourceCompatibility = JavaVersion.VERSION_21
-//	targetCompatibility = JavaVersion.VERSION_21
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 // jar 제외하고 bootjar 로만 실행파일생성
 jar {
@@ -92,4 +91,27 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// 아래는 소형/중형 테스트 분리를 위한 설정임
+tasks.register('smallTest', Test) {
+	useJUnitPlatform {
+		excludeTags 'middleTest'
+	}
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	shouldRunAfter test
+	reports.junitXml.destination = layout.buildDirectory.dir("test-results/smallTest").get().asFile
+	reports.html.destination = layout.buildDirectory.dir("reports/tests/smallTest").get().asFile
+}
+
+tasks.register('middleTest', Test) {
+	useJUnitPlatform {
+		includeTags 'middleTest'
+	}
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	shouldRunAfter test
+	reports.junitXml.destination = layout.buildDirectory.dir("test-results/integrationTest").get().asFile
+	reports.html.destination = layout.buildDirectory.dir("reports/tests/integrationTest").get().asFile
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'RestaurantTier'
+rootProject.name = 'kustaurant'

--- a/src/test/java/com/kustaurant/kustaurant/post/PostCommentServiceTest.java
+++ b/src/test/java/com/kustaurant/kustaurant/post/PostCommentServiceTest.java
@@ -76,7 +76,7 @@ class PostCommentServiceTest {
         // When & Then
         assertThatThrownBy(() -> commentService.getPostCommentByCommentId(commentId))
                 .isInstanceOf(DataNotFoundException.class)
-                .hasMessage("PostComment not found");
+                .hasMessage("ID가 1인 댓글이(가) 존재하지 않습니다.");
     }
 
     @Test
@@ -112,7 +112,7 @@ class PostCommentServiceTest {
         ReactionToggleResponse response = commentService.toggleLike(userId, commentId);
 
         // Then
-        assertThat(response.getStatus()).isEqualTo(ReactionStatus.DISLIKE_TO_LIKE);
+        assertThat(response.getStatus()).isEqualTo(ReactionStatus.LIKE_CREATED);
         assertThat(response.getLikeCount()).isEqualTo(1);
         assertThat(response.getDislikeCount()).isEqualTo(0);
     }

--- a/src/test/java/com/kustaurant/kustaurant/user/mypage/service/MypageApiServiceIT.java
+++ b/src/test/java/com/kustaurant/kustaurant/user/mypage/service/MypageApiServiceIT.java
@@ -11,6 +11,7 @@ import com.kustaurant.kustaurant.restaurant.restaurant.service.RestaurantFavorit
 import com.kustaurant.kustaurant.restaurant.restaurant.service.constants.RestaurantConstants;
 import com.kustaurant.kustaurant.user.mypage.controller.port.MypageApiService;
 import com.kustaurant.kustaurant.user.mypage.controller.request.ProfileUpdateRequest;
+import com.kustaurant.kustaurant.user.mypage.controller.response.api.MyRestaurantResponse;
 import com.kustaurant.kustaurant.user.mypage.domain.UserStats;
 import com.kustaurant.kustaurant.user.user.domain.User;
 import com.kustaurant.kustaurant.user.user.domain.enums.UserRole;
@@ -26,9 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -158,7 +159,9 @@ class MypageApiServiceIT {
         var res = mypageApiService.getUserFavoriteRestaurantList(user1.getId());
         //t
         assertEquals(5, res.size());
-        assertThat(res.get(0).restaurantName()).isEqualTo("한식당1");
+        assertThat(res)
+                .extracting(MyRestaurantResponse::restaurantName)
+                .contains("한식당1");
     }
 
     // 7
@@ -173,6 +176,8 @@ class MypageApiServiceIT {
                         List.of(new RestaurantConstants.StarComment(6, "신선해요")),
                         null
                 );
+        evaluationService.evaluate(user1.getId(), 1, dto1);
+
         EvaluationDTO dto2 = new EvaluationDTO(
                         1.5,
                         List.of(),
@@ -181,8 +186,6 @@ class MypageApiServiceIT {
                         List.of(new RestaurantConstants.StarComment(1, "신선하지 않네요")),
                         null
                 );
-
-        evaluationService.evaluate(user1.getId(), 1, dto1);
         evaluationService.evaluate(user1.getId(), 2, dto2);
         //w
         var res = mypageApiService.getUserEvaluateRestaurantList(user1.getId());

--- a/src/test/java/com/kustaurant/kustaurant/user/mypage/service/MypageApiServiceIT.java
+++ b/src/test/java/com/kustaurant/kustaurant/user/mypage/service/MypageApiServiceIT.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
+@Tag("middleTest")
 class MypageApiServiceIT {
 
     @Autowired MypageApiService mypageApiService;

--- a/src/test/java/com/kustaurant/kustaurant/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/kustaurant/kustaurant/user/service/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.kustaurant.kustaurant.user.service;
 
+import com.kustaurant.kustaurant.global.exception.exception.business.UserNotFoundException;
 import com.kustaurant.kustaurant.user.user.domain.User;
 import com.kustaurant.kustaurant.user.user.domain.enums.UserStatus;
 import com.kustaurant.kustaurant.user.user.domain.vo.Nickname;
@@ -67,6 +68,6 @@ class UserServiceImplTest {
         //t
         assertThatThrownBy(()->{
             userServiceImpl.getUserById(2L);
-        }).isInstanceOf(DataNotFoundException.class);
+        }).isInstanceOf(UserNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- 프로젝트 자바 버전 21로 업그레이드 했습니다.

- 깃헙 액션:  [deveop / main] 브랜치로 pr시 자동테스트 실행 추가했습니다. 
  테스트의 변경사항이 없는경우 재 pr시에 별도 테스트수행을 진행하지 않습니다.

- 소형/중형 테스트 분리
  기본적으로 테스트 돌리면 소형/중형 테스트 모두 실행됨
  소형 중형 테스트 출력결과 분리를 위해  ./gradlew smallTest ./gradlew middleTest 실행 가능
  중형 테스트는 네이밍 뒤를 test가 아닌 IT 로 하는것 제안 및 클래스 위에 @Tag("middleTest") 붙여줘야함

- 프로젝트 네임 RestaurantTier -> Kustaurant 변경
<img width="300" height="100" alt="image" src="https://github.com/user-attachments/assets/cea0ac55-52eb-4d57-bdff-8c514fec0aba" />
 -> 
<img width="300" height="100" alt="image" src="https://github.com/user-attachments/assets/a1c79637-bc2e-444c-af46-1d53a351517d" />

## 할 말(?)
1. 소형/중형 테스트 자체를 패키지분리 해보려 했으나 생각보다 빡세시 일단 그냥 @Tag 애노테이션 방식 채택
2. github action 에서 secret key 같은거 github의 secret repository에서 있는 .env로 해보려 했으나 안됨;;;; 나중에 다시 공부더 하거나 해서 변경 하겠음. 지금은 임시 데이터들을 직접 github action 의 workflow에서 코드로 넣어주는 방식으로 작동

## 해야할것
실패하는 post도메인쪽 테스트코드 성공시키기 (작업중일 가능성이 있어 여기선 수정 안함)

<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
