### PR TITLE
feat: 네이버 플레이스 크롤링 안정성, 성능 개선

### DIFF
--- a/.github/workflows/pre-test.yml
+++ b/.github/workflows/pre-test.yml
@@ -27,13 +27,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Run small tests
-        run: ./gradlew --no-daemon clean smallTest
+        run: ./gradlew --no-daemon :server:kustaurant:test
 
       - name: Publish Small Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: server/kustaurant/build/test-results/smallTest/TEST-*.xml
+          files: server/kustaurant/build/test-results/test/TEST-*.xml
           check_name: 🧪 소형(단위) 테스트 결과
           check_run: false
 
@@ -42,7 +42,7 @@ jobs:
   #        uses: dorny/test-reporter@v1
   #        with:
   #          name: 🧪 소형 테스트 리포트
-  #          path: build/test-results/smallTest/*.xml
+  #          path: server/kustaurant/build/test-results/test/*.xml
   #          reporter: java-junit
 
   middle-test:
@@ -78,13 +78,13 @@ jobs:
         run: docker info
 
       - name: Run middle tests
-        run: ./gradlew --no-daemon middleTest
+        run: ./gradlew --no-daemon :server:kustaurant:integrationTest
 
       - name: Publish Middle Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: server/kustaurant/build/test-results/middleTest/TEST-*.xml
+          files: server/kustaurant/build/test-results/integrationTest/TEST-*.xml
           check_name: 🚀 중형(통합) 테스트 결과
           check_run: false
 #        작동 시간이 길어지고, 테스트 결과 표출과 리포트 남기기는 같이 적용이 안됨. 둘중 하나만 적용됨
@@ -93,5 +93,5 @@ jobs:
 #        uses: dorny/test-reporter@v1
 #        with:
 #          name: 🚀 중형 테스트 리포트
-#          path: build/test-results/middleTest/*.xml
+#          path: server/kustaurant/build/test-results/integrationTest/*.xml
 #          reporter: java-junit

--- a/common/jpa/src/main/java/com/kustaurant/restaurantSync/sync/ZoneCrawlJobStatus.java
+++ b/common/jpa/src/main/java/com/kustaurant/restaurantSync/sync/ZoneCrawlJobStatus.java
@@ -1,8 +1,9 @@
 package com.kustaurant.restaurantSync.sync;
 
-public enum ZoneJCrawlobStatus {
+public enum ZoneCrawlJobStatus {
    PENDING,
    RUNNING,
+   CAPTCHA_REQUIRED,
    SUCCESS,
    FAILED;
 }

--- a/common/jpa/src/main/java/com/kustaurant/restaurantSync/sync/ZoneCrawlStatusPayload.java
+++ b/common/jpa/src/main/java/com/kustaurant/restaurantSync/sync/ZoneCrawlStatusPayload.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record ZoneCrawlStatusPayload(
         // 서버 간 통신용 -> 쿠스토랑 서버가 폴링으로 현재 작업 진행상태 받아오는 용
-        ZoneJCrawlobStatus status,
+        ZoneCrawlJobStatus status,
         int totalGridCount,
         int processedGridCount,
         int discoveredPlaceCount,

--- a/server/crawler/scripts/benchmark-zone-crawler.ps1
+++ b/server/crawler/scripts/benchmark-zone-crawler.ps1
@@ -1,0 +1,242 @@
+param(
+    [string]$Zone = "GUI_STATION",
+    [int]$Port = 18081,
+    [int]$PollSeconds = 15,
+    [int]$MaxGrids = 1,
+    [int]$MaxPlaceIds = 10,
+    [ValidateSet("BOTH", "LEGACY", "APOLLO_FIRST")]
+    [string]$BenchmarkMode = "BOTH"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+$jarPath = (Resolve-Path (Join-Path $repoRoot "server\crawler\build\libs\crawler-0.0.1.jar")).Path
+$runId = Get-Date -Format "yyyyMMdd-HHmmss"
+$outputDir = Join-Path $repoRoot "server\crawler\build\benchmark\$Zone-$runId"
+New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+
+function Wait-ForCrawler([System.Diagnostics.Process]$Process, [string]$BaseUrl) {
+    $deadline = (Get-Date).AddMinutes(3)
+    while ((Get-Date) -lt $deadline) {
+        if ($Process.HasExited) {
+            throw "Crawler process exited during startup with code $($Process.ExitCode)."
+        }
+        try {
+            $health = Invoke-RestMethod -Uri "$BaseUrl/actuator/health" -TimeoutSec 3
+            if ($health.status -eq "UP") {
+                return
+            }
+        } catch {
+            Start-Sleep -Seconds 2
+        }
+    }
+    throw "Crawler did not become healthy within 3 minutes."
+}
+
+function Stop-Crawler([System.Diagnostics.Process]$Process) {
+    if ($null -eq $Process -or $Process.HasExited) {
+        return
+    }
+    Stop-Process -Id $Process.Id
+    $Process.WaitForExit(15000) | Out-Null
+}
+
+function Invoke-CrawlMode([string]$Mode, [int]$ModePort) {
+    $stdoutPath = Join-Path $outputDir "$Mode.stdout.log"
+    $stderrPath = Join-Path $outputDir "$Mode.stderr.log"
+    $baseUrl = "http://127.0.0.1:$ModePort"
+    $javaArgs = @(
+        "-Dspring.profiles.active=local",
+        "-jar", $jarPath,
+        "--server.port=$ModePort",
+        "--crawler.naver-place.detail-mode=$Mode",
+        "--crawler.naver-place.max-grids=$MaxGrids",
+        "--crawler.naver-place.max-place-ids=$MaxPlaceIds",
+        "--spring.data.redis.database=15",
+        "--streams.ai-analysis-crawling=kustaurant-benchmark-crawling",
+        "--streams.ai-analysis-review=kustaurant-benchmark-review",
+        "--streams.ai-analysis-dlq=kustaurant-benchmark-dlq",
+        "--streams.group=kustaurant-benchmark",
+        "--spring.main.banner-mode=off"
+    )
+
+    Write-Host "[$Mode] crawler starting..."
+    $process = Start-Process -FilePath "java.exe" -ArgumentList $javaArgs `
+        -WorkingDirectory $repoRoot -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath -WindowStyle Hidden -PassThru
+
+    try {
+        Wait-ForCrawler -Process $process -BaseUrl $baseUrl
+        Write-Host "[$Mode] crawler is healthy. Starting zone=$Zone"
+
+        $body = @{ crawlScope = $Zone } | ConvertTo-Json
+        $job = Invoke-RestMethod -Method Post -Uri "$BaseUrl/api/naver-place/crawl-zone/jobs" `
+            -ContentType "application/json" -Body $body -TimeoutSec 30
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $lastProgressLine = ""
+
+        while ($true) {
+            Start-Sleep -Seconds $PollSeconds
+            $status = Invoke-RestMethod -Uri "$BaseUrl/api/naver-place/crawl-zone/jobs/$($job.jobId)" -TimeoutSec 30
+            $progressLine = "status=$($status.status) grid=$($status.processedGridCount)/$($status.totalGridCount) discovered=$($status.discoveredPlaceCount) attempted=$($status.attemptedPlaceCount) success=$($status.crawledSuccessCount) failed=$($status.finalFailedCount) elapsed=$([math]::Round($stopwatch.Elapsed.TotalMinutes, 1))m"
+            if ($progressLine -ne $lastProgressLine) {
+                Write-Host "[$Mode] $progressLine"
+                $lastProgressLine = $progressLine
+            }
+
+            if ($status.status -eq "SUCCESS") {
+                break
+            }
+            if ($status.status -eq "FAILED") {
+                throw "Zone crawl failed: $($status.errorMessage)"
+            }
+            if ($status.status -eq "CAPTCHA_REQUIRED") {
+                throw "Zone crawl paused by Naver captcha at grid=$($status.currentGrid): $($status.errorMessage)"
+            }
+        }
+
+        $stopwatch.Stop()
+        $payload = Invoke-RestMethod -Uri "$BaseUrl/api/naver-place/crawl-zone/jobs/$($job.jobId)/results?fromIndex=0&limit=500" -TimeoutSec 60
+        $modeResult = [ordered]@{
+            mode = $Mode
+            zone = $Zone
+            durationSeconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+            status = $status
+            resultCount = @($payload.results).Count
+            results = @($payload.results)
+        }
+        $modePath = Join-Path $outputDir "$Mode.json"
+        $modeResult | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $modePath
+        Write-Host "[$Mode] completed in $([math]::Round($stopwatch.Elapsed.TotalMinutes, 2))m; results=$(@($payload.results).Count)"
+        return [pscustomobject]$modeResult
+    } catch {
+        Write-Host "[$Mode] failed. Recent application logs:"
+        if (Test-Path $stdoutPath) {
+            Get-Content $stdoutPath -Tail 80 | Write-Host
+        }
+        if (Test-Path $stderrPath) {
+            Get-Content $stderrPath -Tail 80 | Write-Host
+        }
+        throw
+    } finally {
+        Stop-Crawler -Process $process
+    }
+}
+
+function Canonical-Menus($Menus) {
+    if ($null -eq $Menus) {
+        return "[]"
+    }
+    $canonical = @($Menus | ForEach-Object {
+        [ordered]@{
+            menuName = $_.menuName
+            menuPrice = $_.menuPrice
+            menuImageUrl = $_.menuImageUrl
+        }
+    } | Sort-Object menuName, menuPrice, menuImageUrl)
+    return ($canonical | ConvertTo-Json -Compress -Depth 5)
+}
+
+function Compare-Results($Legacy, $Apollo) {
+    $legacyById = @{}
+    foreach ($item in $Legacy.results) { $legacyById[$item.sourcePlaceId] = $item }
+    $apolloById = @{}
+    foreach ($item in $Apollo.results) { $apolloById[$item.sourcePlaceId] = $item }
+
+    $legacyIds = @($legacyById.Keys)
+    $apolloIds = @($apolloById.Keys)
+    $commonIds = @($legacyIds | Where-Object { $apolloById.ContainsKey($_) } | Sort-Object)
+    $onlyLegacy = @($legacyIds | Where-Object { -not $apolloById.ContainsKey($_) } | Sort-Object)
+    $onlyApollo = @($apolloIds | Where-Object { -not $legacyById.ContainsKey($_) } | Sort-Object)
+    $fields = @("placeName", "category", "restaurantAddress", "phoneNumber", "latitude", "longitude", "imageUrl", "crawlScope")
+    $fieldDiffCounts = [ordered]@{}
+    foreach ($field in $fields) { $fieldDiffCounts[$field] = 0 }
+    $fieldDiffCounts["menus"] = 0
+    $exactMatchCount = 0
+    $mismatches = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($id in $commonIds) {
+        $left = $legacyById[$id]
+        $right = $apolloById[$id]
+        $changedFields = [System.Collections.Generic.List[string]]::new()
+        foreach ($field in $fields) {
+            if ($left.$field -ne $right.$field) {
+                $fieldDiffCounts[$field]++
+                $changedFields.Add($field)
+            }
+        }
+        if ((Canonical-Menus $left.menus) -ne (Canonical-Menus $right.menus)) {
+            $fieldDiffCounts["menus"]++
+            $changedFields.Add("menus")
+        }
+
+        if ($changedFields.Count -eq 0) {
+            $exactMatchCount++
+        } elseif ($mismatches.Count -lt 30) {
+            $mismatches.Add([ordered]@{
+                sourcePlaceId = $id
+                legacyName = $left.placeName
+                apolloName = $right.placeName
+                changedFields = @($changedFields)
+                legacyMenuCount = @($left.menus).Count
+                apolloMenuCount = @($right.menus).Count
+            })
+        }
+    }
+
+    $speedup = if ($Apollo.durationSeconds -gt 0) {
+        [math]::Round($Legacy.durationSeconds / $Apollo.durationSeconds, 3)
+    } else { $null }
+
+    return [ordered]@{
+        zone = $Zone
+        outputDirectory = $outputDir
+        legacy = [ordered]@{
+            durationSeconds = $Legacy.durationSeconds
+            discovered = $Legacy.status.discoveredPlaceCount
+            attempted = $Legacy.status.attemptedPlaceCount
+            success = $Legacy.status.crawledSuccessCount
+            failed = $Legacy.status.finalFailedCount
+            resultCount = $Legacy.resultCount
+        }
+        apolloFirst = [ordered]@{
+            durationSeconds = $Apollo.durationSeconds
+            discovered = $Apollo.status.discoveredPlaceCount
+            attempted = $Apollo.status.attemptedPlaceCount
+            success = $Apollo.status.crawledSuccessCount
+            failed = $Apollo.status.finalFailedCount
+            resultCount = $Apollo.resultCount
+        }
+        legacyToApolloSpeedup = $speedup
+        commonResultCount = $commonIds.Count
+        exactMatchCount = $exactMatchCount
+        exactMatchRate = if ($commonIds.Count -gt 0) { [math]::Round($exactMatchCount / $commonIds.Count, 4) } else { $null }
+        onlyLegacyIds = $onlyLegacy
+        onlyApolloIds = $onlyApollo
+        fieldDiffCounts = $fieldDiffCounts
+        mismatchExamples = @($mismatches)
+    }
+}
+
+if ($BenchmarkMode -eq "BOTH") {
+    $legacyResult = Invoke-CrawlMode -Mode "LEGACY" -ModePort $Port
+    $apolloResult = Invoke-CrawlMode -Mode "APOLLO_FIRST" -ModePort ($Port + 1)
+    $comparison = Compare-Results -Legacy $legacyResult -Apollo $apolloResult
+    $comparisonPath = Join-Path $outputDir "comparison.json"
+    $comparison | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $comparisonPath
+    Write-Host "Comparison saved to $comparisonPath"
+    $comparison | ConvertTo-Json -Depth 20
+} else {
+    $singleResult = Invoke-CrawlMode -Mode $BenchmarkMode -ModePort $Port
+    [ordered]@{
+        mode = $singleResult.mode
+        zone = $singleResult.zone
+        durationSeconds = $singleResult.durationSeconds
+        discovered = $singleResult.status.discoveredPlaceCount
+        attempted = $singleResult.status.attemptedPlaceCount
+        success = $singleResult.status.crawledSuccessCount
+        failed = $singleResult.status.finalFailedCount
+        resultCount = $singleResult.resultCount
+        outputDirectory = $outputDir
+    } | ConvertTo-Json -Depth 10
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/controller/RestaurantCrawlController.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/controller/RestaurantCrawlController.java
@@ -53,12 +53,24 @@ public class RestaurantCrawlController {
       return zoneCrawlJobService.start(request.crawlScope());
    }
 
-   // 5. 구역 크롤 작업 상태 조회
+   // 5. 보안 인증 대기 중인 구역 크롤 작업 재개
+   @PostMapping({"/crawl-zone/jobs/{jobId}/resume"})
+   public CrawlJobIdResponse resumeZoneCrawlJob(@PathVariable String jobId) {
+      try {
+         return zoneCrawlJobService.resume(jobId).orElseThrow(
+                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "zone crawl job not found: " + jobId)
+         );
+      } catch (IllegalStateException e) {
+         throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage(), e);
+      }
+   }
+
+   // 6. 구역 크롤 작업 상태 조회
    @GetMapping({"/crawl-zone/jobs/{jobId}"})
    public ZoneCrawlStatusPayload getZoneCrawlJobStatus(@PathVariable String jobId) {
       return zoneCrawlJobService.getStatus(jobId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "zone crawl job not found: " + jobId));
    }
-   // 6. 증분 결과 조회 (구역 크롤 실시간 배치 저장용 (현재 10개씩))
+   // 7. 증분 결과 조회 (구역 크롤 실시간 배치 저장용 (현재 10개씩))
    @GetMapping({"/crawl-zone/jobs/{jobId}/results"})
    public ZoneCrawlJobResultsPayload getZoneCrawlJobResults(
            @PathVariable String jobId,

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/NaverApolloStateParser.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/NaverApolloStateParser.java
@@ -1,0 +1,367 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kustaurant.restaurantSync.RestaurantRawMenu;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NaverApolloStateParser {
+
+   private static final String APOLLO_STATE_MARKER = "window.__APOLLO_STATE__";
+   private static final String PLACE_DETAIL_BASE_PREFIX = "PlaceDetailBase:";
+
+   private final ObjectMapper objectMapper;
+
+   public Optional<NaverPlaceData> parse(String html, String placeId) {
+      if (isBlank(html) || isBlank(placeId)) {
+         return Optional.empty();
+      }
+
+      try {
+         String stateJson = extractAssignedJsonObject(html, APOLLO_STATE_MARKER);
+         if (stateJson == null) {
+            return Optional.empty();
+         }
+
+         JsonNode state = objectMapper.readTree(stateJson);
+         JsonNode base = findPlaceDetailBase(state, placeId);
+         if (base == null) {
+            return Optional.empty();
+         }
+
+         JsonNode placeDetail = findPlaceDetail(state, placeId);
+         MenuResult menuResult = extractMenus(state, placeDetail, placeId);
+
+         return Optional.of(new NaverPlaceData(
+                 text(base, "name"),
+                 text(base, "category"),
+                 firstNonBlank(text(base, "roadAddress"), text(base, "address")),
+                 firstNonBlank(
+                         textAt(placeDetail, "phoneInfo", "phone"),
+                         text(base, "virtualPhone"),
+                         text(base, "phone")
+                 ),
+                 doubleAt(base, "coordinate", "y"),
+                 doubleAt(base, "coordinate", "x"),
+                 extractRepresentativeImage(state, placeDetail),
+                 menuResult.menus(),
+                 menuResult.authoritative()
+         ));
+      } catch (Exception ignored) {
+         return Optional.empty();
+      }
+   }
+
+   private JsonNode findPlaceDetailBase(JsonNode state, String placeId) {
+      JsonNode exact = state.get(PLACE_DETAIL_BASE_PREFIX + placeId);
+      if (isTypeWithId(exact, "PlaceDetailBase", placeId)) {
+         return exact;
+      }
+
+      for (JsonNode candidate : state) {
+         if (isTypeWithId(candidate, "PlaceDetailBase", placeId)) {
+            return candidate;
+         }
+      }
+      return null;
+   }
+
+   private JsonNode findPlaceDetail(JsonNode state, String placeId) {
+      String expectedBaseRef = PLACE_DETAIL_BASE_PREFIX + placeId;
+      for (JsonNode candidate : state) {
+         JsonNode found = findObject(candidate, node ->
+                 "PlaceDetail".equals(text(node, "__typename"))
+                         && expectedBaseRef.equals(textAt(node, "base", "__ref"))
+         );
+         if (found != null) {
+            return found;
+         }
+      }
+      return null;
+   }
+
+   private MenuResult extractMenus(JsonNode state, JsonNode placeDetail, String placeId) {
+      JsonNode menuRefs = findFieldByLogicalName(placeDetail, "menus");
+      if (menuRefs != null && menuRefs.isArray()) {
+         List<RestaurantRawMenu> resolved = resolveMenus(state, menuRefs);
+         boolean authoritative = menuRefs.isEmpty() || resolved.size() == menuRefs.size();
+         return new MenuResult(resolved, authoritative);
+      }
+
+      Map<String, RestaurantRawMenu> discovered = new LinkedHashMap<>();
+      Iterator<String> fields = state.fieldNames();
+      while (fields.hasNext()) {
+         String field = fields.next();
+         JsonNode candidate = state.get(field);
+         if (!isMenuForPlace(candidate, placeId)) {
+            continue;
+         }
+         RestaurantRawMenu menu = toMenu(candidate);
+         if (menu != null) {
+            discovered.putIfAbsent(field, menu);
+         }
+      }
+      return new MenuResult(new ArrayList<>(discovered.values()), false);
+   }
+
+   private List<RestaurantRawMenu> resolveMenus(JsonNode state, JsonNode menuRefs) {
+      List<RestaurantRawMenu> menus = new ArrayList<>();
+      for (JsonNode item : menuRefs) {
+         JsonNode menuNode = item;
+         String reference = text(item, "__ref");
+         if (!isBlank(reference)) {
+            menuNode = state.get(reference);
+         }
+
+         RestaurantRawMenu menu = toMenu(menuNode);
+         if (menu != null) {
+            menus.add(menu);
+         }
+      }
+      return menus;
+   }
+
+   private RestaurantRawMenu toMenu(JsonNode menuNode) {
+      if (menuNode == null || !"Menu".equals(text(menuNode, "__typename"))) {
+         return null;
+      }
+
+      String name = text(menuNode, "name");
+      if (isBlank(name)) {
+         return null;
+      }
+
+      return new RestaurantRawMenu(
+              name,
+              formatMenuPrice(text(menuNode, "price")),
+              firstArrayText(menuNode.get("images"))
+      );
+   }
+
+   private String extractRepresentativeImage(JsonNode state, JsonNode placeDetail) {
+      String image = firstNonBlank(
+              textAt(placeDetail, "images", "images", 0, "origin"),
+              textAt(placeDetail, "images", "images", 0, "url")
+      );
+      if (!isBlank(image)) {
+         return image;
+      }
+
+      JsonNode topPhotos = placeDetail == null ? null : placeDetail.path("topPhotos").path("items");
+      if (topPhotos != null && topPhotos.isArray()) {
+         for (JsonNode item : topPhotos) {
+            String reference = text(item, "__ref");
+            JsonNode photo = isBlank(reference) ? item : state.get(reference);
+            if (photo == null || !"business".equals(text(photo, "mediaSource"))) {
+               continue;
+            }
+            image = firstNonBlank(text(photo, "originalUrl"), text(photo, "thumbnailUrl"));
+            if (!isBlank(image)) {
+               return image;
+            }
+         }
+      }
+      return null;
+   }
+
+   private JsonNode findFieldByLogicalName(JsonNode object, String logicalName) {
+      if (object == null || !object.isObject()) {
+         return null;
+      }
+
+      Iterator<String> fields = object.fieldNames();
+      while (fields.hasNext()) {
+         String field = fields.next();
+         if (field.equals(logicalName) || field.startsWith(logicalName + "(")) {
+            return object.get(field);
+         }
+      }
+      return null;
+   }
+
+   private JsonNode findObject(JsonNode node, NodePredicate predicate) {
+      if (node == null) {
+         return null;
+      }
+      if (node.isObject() && predicate.matches(node)) {
+         return node;
+      }
+      if (!node.isContainerNode()) {
+         return null;
+      }
+
+      for (JsonNode child : node) {
+         JsonNode found = findObject(child, predicate);
+         if (found != null) {
+            return found;
+         }
+      }
+      return null;
+   }
+
+   private boolean isMenuForPlace(JsonNode candidate, String placeId) {
+      return candidate != null
+              && "Menu".equals(text(candidate, "__typename"))
+              && text(candidate, "id") != null
+              && text(candidate, "id").startsWith(placeId + "_");
+   }
+
+   private boolean isTypeWithId(JsonNode node, String typename, String id) {
+      return node != null
+              && typename.equals(text(node, "__typename"))
+              && id.equals(text(node, "id"));
+   }
+
+   private String extractAssignedJsonObject(String source, String marker) {
+      int markerIndex = source.indexOf(marker);
+      if (markerIndex < 0) {
+         return null;
+      }
+
+      int assignmentIndex = source.indexOf('=', markerIndex + marker.length());
+      if (assignmentIndex < 0) {
+         return null;
+      }
+
+      int objectStart = source.indexOf('{', assignmentIndex + 1);
+      if (objectStart < 0) {
+         return null;
+      }
+
+      boolean inString = false;
+      boolean escaped = false;
+      int depth = 0;
+      for (int i = objectStart; i < source.length(); i++) {
+         char current = source.charAt(i);
+         if (inString) {
+            if (escaped) {
+               escaped = false;
+            } else if (current == '\\') {
+               escaped = true;
+            } else if (current == '"') {
+               inString = false;
+            }
+            continue;
+         }
+
+         if (current == '"') {
+            inString = true;
+         } else if (current == '{') {
+            depth++;
+         } else if (current == '}') {
+            depth--;
+            if (depth == 0) {
+               return source.substring(objectStart, i + 1);
+            }
+         }
+      }
+      return null;
+   }
+
+   private String formatMenuPrice(String value) {
+      if (isBlank(value)) {
+         return "변동";
+      }
+      String normalized = value.trim();
+      if ("0".equals(normalized)) {
+         return "무료";
+      }
+      if (!normalized.matches("\\d+")) {
+         return normalized;
+      }
+      try {
+         return String.format("%,d원", Long.parseLong(normalized));
+      } catch (NumberFormatException ignored) {
+         return normalized;
+      }
+   }
+
+   private String firstArrayText(JsonNode array) {
+      if (array == null || !array.isArray() || array.isEmpty()) {
+         return null;
+      }
+      return normalize(array.get(0).asText(null));
+   }
+
+   private Double doubleAt(JsonNode root, String objectField, String valueField) {
+      String value = textAt(root, objectField, valueField);
+      if (isBlank(value)) {
+         return null;
+      }
+      try {
+         return Double.parseDouble(value);
+      } catch (NumberFormatException ignored) {
+         return null;
+      }
+   }
+
+   private String text(JsonNode node, String field) {
+      if (node == null || field == null) {
+         return null;
+      }
+      JsonNode value = node.get(field);
+      return value == null || value.isNull() ? null : normalize(value.asText(null));
+   }
+
+   private String textAt(JsonNode root, Object... path) {
+      JsonNode current = root;
+      for (Object part : path) {
+         if (current == null) {
+            return null;
+         }
+         if (part instanceof String field) {
+            current = current.get(field);
+         } else if (part instanceof Integer index) {
+            current = current.isArray() && current.size() > index ? current.get(index) : null;
+         }
+      }
+      return current == null || current.isNull() ? null : normalize(current.asText(null));
+   }
+
+   private String firstNonBlank(String... values) {
+      for (String value : values) {
+         if (!isBlank(value)) {
+            return value;
+         }
+      }
+      return null;
+   }
+
+   private String normalize(String value) {
+      return value == null ? null : value.replaceAll("\\s+", " ").trim();
+   }
+
+   private boolean isBlank(String value) {
+      return value == null || value.isBlank();
+   }
+
+   @FunctionalInterface
+   private interface NodePredicate {
+      boolean matches(JsonNode node);
+   }
+
+   private record MenuResult(List<RestaurantRawMenu> menus, boolean authoritative) {
+   }
+
+   public record NaverPlaceData(
+           String placeName,
+           String category,
+           String restaurantAddress,
+           String phoneNumber,
+           Double latitude,
+           Double longitude,
+           String imageUrl,
+           List<RestaurantRawMenu> menus,
+           boolean menuDataPresent
+   ) {
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantMenuDataResolver.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantMenuDataResolver.java
@@ -1,0 +1,22 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import com.kustaurant.crawler.RestaurantSync.service.single.NaverApolloStateParser.NaverPlaceData;
+import com.kustaurant.restaurantSync.RestaurantRawMenu;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestaurantMenuDataResolver {
+
+   public List<RestaurantRawMenu> resolve(
+           Optional<NaverPlaceData> apolloData,
+           Supplier<List<RestaurantRawMenu>> domMenus
+   ) {
+      return apolloData
+              .filter(NaverPlaceData::menuDataPresent)
+              .map(NaverPlaceData::menus)
+              .orElseGet(domMenus);
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantResponseCollector.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantResponseCollector.java
@@ -1,6 +1,7 @@
 package com.kustaurant.crawler.RestaurantSync.service.single;
 
 import com.microsoft.playwright.Response;
+import java.net.URI;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Generated;
@@ -20,6 +21,17 @@ public class RestaurantResponseCollector {
            AtomicReference<String> menuHtmlRef,
            boolean analyzeMode
    ) {
+      captureHtmlResponse(response, placeId, homeHtmlRef, menuHtmlRef, analyzeMode, true);
+   }
+
+   public void captureHtmlResponse(
+           Response response,
+           String placeId,
+           AtomicReference<String> homeHtmlRef,
+           AtomicReference<String> menuHtmlRef,
+           boolean analyzeMode,
+           boolean captureInitialPlaceDocument
+   ) {
       try {
          String url = response.url();
          String contentType = ((String) response.headers().getOrDefault("content-type", ""))
@@ -28,20 +40,47 @@ public class RestaurantResponseCollector {
             return;
          }
 
-         String homePath = "/restaurant/" + placeId + "/home";
-         String menuPath = "/restaurant/" + placeId + "/menu";
-         if (url.contains(homePath)) {
+         if (isHomeDocument(url, placeId, captureInitialPlaceDocument)) {
             captureHomeHtml(url, response, homeHtmlRef, analyzeMode);
             return;
          }
 
-         if (url.contains(menuPath)) {
+         if (isMenuDocument(url, placeId)) {
             captureMenuHtml(url, response, menuHtmlRef, analyzeMode);
          }
       } catch (Exception e) {
          if (analyzeMode) {
             log.warn("html 응답 캡처 중 오류", e);
          }
+      }
+   }
+
+   private boolean isHomeDocument(String url, String placeId, boolean captureInitialPlaceDocument) {
+      String path = pathOf(url);
+      return (captureInitialPlaceDocument && path.equals("/place/" + placeId))
+              || path.equals("/place/" + placeId + "/home")
+              || path.equals("/restaurant/" + placeId)
+              || path.equals("/restaurant/" + placeId + "/home");
+   }
+
+   private boolean isMenuDocument(String url, String placeId) {
+      String path = pathOf(url);
+      return path.equals("/place/" + placeId + "/menu")
+              || path.equals("/restaurant/" + placeId + "/menu");
+   }
+
+   private String pathOf(String url) {
+      try {
+         URI uri = URI.create(url);
+         if (!"pcmap.place.naver.com".equalsIgnoreCase(uri.getHost())) {
+            return "";
+         }
+         String path = uri.getPath() == null ? "" : uri.getPath();
+         return path.length() > 1 && path.endsWith("/")
+                 ? path.substring(0, path.length() - 1)
+                 : path;
+      } catch (IllegalArgumentException ignored) {
+         return "";
       }
    }
 
@@ -136,6 +175,7 @@ public class RestaurantResponseCollector {
               || html.contains("lnJFt")
               || html.contains("PIbes")
               || html.contains("xlx7Q")
+              || html.contains("window.__APOLLO_STATE__")
               || html.contains("주소")
               || html.contains("전화번호")
               || html.contains("og:title");

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantSingleCrawler.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantSingleCrawler.java
@@ -2,6 +2,7 @@ package com.kustaurant.crawler.RestaurantSync.service.single;
 
 import com.kustaurant.crawler.infrastructure.crawler.playwright.PlaywrightManager;
 import com.kustaurant.crawler.RestaurantSync.service.zone.ZoneResultPolicy;
+import com.kustaurant.crawler.RestaurantSync.service.single.NaverApolloStateParser.NaverPlaceData;
 import com.kustaurant.map.CoordinateV2;
 import com.kustaurant.restaurantSync.RestaurantRawMenu;
 import com.kustaurant.restaurantSync.RestaurantRaw;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -22,15 +24,25 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RestaurantSingleCrawler {
 
+   enum DetailMode {
+      LEGACY,
+      APOLLO_FIRST
+   }
+
    private static final int MAX_RETRIES = 2;
    private static final String NAVER_PLACE_NOT_FOUND_TEXT = "요청하신 페이지를 찾을 수 없습니다.";
 
    private final PlaywrightManager playwrightManager;
    private final RestaurantPageDriver pageDriver;
    private final RestaurantResponseCollector responseCollector;
+   private final NaverApolloStateParser apolloStateParser;
    private final RestaurantInfoExtractor infoExtractor;
    private final RestaurantMenuExtractor menuExtractor;
+   private final RestaurantMenuDataResolver menuDataResolver;
    private final ZoneResultPolicy zoneResultPolicy;
+
+   @Value("${crawler.naver-place.detail-mode:APOLLO_FIRST}")
+   private DetailMode detailMode = DetailMode.APOLLO_FIRST;
 
    public RestaurantRaw crawl(String placeUrl) {
       return crawlWithRetry(placeUrl, false);
@@ -63,12 +75,13 @@ public class RestaurantSingleCrawler {
    private RestaurantRaw crawlInternal(String placeUrl, boolean analyzeMode) {
       return playwrightManager.crawl(page -> {
          String placeId = infoExtractor.extractPlaceId(placeUrl);
+         boolean apolloEnabled = detailMode == DetailMode.APOLLO_FIRST;
 
          AtomicReference<String> homeHtmlRef = new AtomicReference<>();
          AtomicReference<String> menuHtmlRef = new AtomicReference<>();
 
          page.onResponse(response -> responseCollector.captureHtmlResponse(
-                 response, placeId, homeHtmlRef, menuHtmlRef, analyzeMode
+                 response, placeId, homeHtmlRef, menuHtmlRef, analyzeMode, apolloEnabled
          ));
 
          if (analyzeMode) {
@@ -80,11 +93,26 @@ public class RestaurantSingleCrawler {
          waitForHomeCapture(page, homeHtmlRef, 6_000);
          hydrateHomeHtmlFromEntryFrameIfMissing(page, homeHtmlRef, analyzeMode, placeId);
 
-         boolean menuClicked = pageDriver.clickMenuTab(page);
-         if (analyzeMode) log.info("메뉴 탭 클릭 여부={}", menuClicked);
+         Optional<NaverPlaceData> initialApolloData = apolloEnabled
+                 ? apolloStateParser.parse(homeHtmlRef.get(), placeId)
+                 : Optional.empty();
+         boolean shouldLoadLegacyMenuPage = !apolloEnabled || initialApolloData
+                 .map(data -> !data.menuDataPresent())
+                 .orElse(true);
 
-
-         if (menuClicked) pageDriver.waitForMenuIdle(page);
+         boolean menuClicked = false;
+         if (shouldLoadLegacyMenuPage) {
+            menuClicked = pageDriver.clickMenuTab(page);
+            if (menuClicked) pageDriver.waitForMenuIdle(page);
+         }
+         if (analyzeMode) {
+            log.info(
+                    "Apollo 초기 데이터 감지={}, Apollo 메뉴 데이터 감지={}, 메뉴 탭 클릭 여부={}",
+                    initialApolloData.isPresent(),
+                    initialApolloData.map(NaverPlaceData::menuDataPresent).orElse(false),
+                    menuClicked
+            );
+         }
 
          waitForHomeCapture(page, homeHtmlRef, 6_000);
          hydrateHomeHtmlFromEntryFrameIfMissing(page, homeHtmlRef, analyzeMode, placeId);
@@ -100,8 +128,10 @@ public class RestaurantSingleCrawler {
          if (isBlank(liveHomeSnapshot)) liveHomeSnapshot = safePageContent(page);
 
 
-         pageDriver.navigateToDirectMenuIfNeeded(page, placeId, menuHtmlRef.get() != null);
-         waitForHtmlCapture(page, menuHtmlRef, 8_000);
+         if (shouldLoadLegacyMenuPage) {
+            pageDriver.navigateToDirectMenuIfNeeded(page, placeId, menuHtmlRef.get() != null);
+            waitForHtmlCapture(page, menuHtmlRef, 8_000);
+         }
 
          String homeHtml = homeHtmlRef.get();
          String menuHtml = menuHtmlRef.get();
@@ -109,7 +139,12 @@ public class RestaurantSingleCrawler {
          Document menuDoc = isBlank(menuHtml) ? null : Jsoup.parse(menuHtml);
 
          String sourceUrl = safePageUrl(page);
-         RestaurantInfoExtractor.NaverPlaceBasicInfo basicInfo = infoExtractor.extract(homeDoc, homeHtml);
+         Optional<NaverPlaceData> apolloData = apolloEnabled
+                 ? bestApolloData(placeId, homeHtml, menuHtml)
+                 : Optional.empty();
+         RestaurantInfoExtractor.NaverPlaceBasicInfo domBasicInfo = infoExtractor.extract(homeDoc, homeHtml);
+         boolean domBasicFallbackUsed = usesDomBasicFallback(apolloData, domBasicInfo);
+         RestaurantInfoExtractor.NaverPlaceBasicInfo basicInfo = mergeBasicInfo(apolloData, domBasicInfo);
 
          if (hasNoBasicInfo(basicInfo) && !isBlank(liveHomeSnapshot)) {
             Document liveDoc = Jsoup.parse(liveHomeSnapshot);
@@ -125,7 +160,10 @@ public class RestaurantSingleCrawler {
             }
          }
 
-         List<RestaurantRawMenu> menus = menuExtractor.extractMenus(menuDoc, page);
+         List<RestaurantRawMenu> menus = menuDataResolver.resolve(
+                 apolloData,
+                 () -> menuExtractor.extractMenus(menuDoc, page)
+         );
 
          Double latitude = basicInfo.latitude();
          Double longitude = basicInfo.longitude();
@@ -157,6 +195,14 @@ public class RestaurantSingleCrawler {
                log.warn("home html 캡처 실패. sourcePlaceId={}, placeId={}", placeId, placeUrl);
             }
             log.info(
+                    "상세 데이터 소스. sourcePlaceId={}, mode={}, apollo={}, apolloMenu={}, domFallback={}",
+                    placeId,
+                    detailMode,
+                    apolloData.isPresent(),
+                    apolloData.map(NaverPlaceData::menuDataPresent).orElse(false),
+                    domBasicFallbackUsed
+            );
+            log.info(
                     " === 네이버플레이스 분석 완료. sourcePlaceId={}, placeName={}, category={}, restaurantAddress={}, phone={}, lat={}, lng={}, zoneType={}, zoneDescription={}, menuCount={}",
                     result.sourcePlaceId(), result.placeName(), result.category(), result.restaurantAddress(),
                     result.phoneNumber(), result.latitude(), result.longitude(),
@@ -174,6 +220,64 @@ public class RestaurantSingleCrawler {
 
          return result;
       });
+   }
+
+   private Optional<NaverPlaceData> bestApolloData(String placeId, String homeHtml, String menuHtml) {
+      Optional<NaverPlaceData> homeData = apolloStateParser.parse(homeHtml, placeId);
+      if (homeData.map(NaverPlaceData::menuDataPresent).orElse(false)) {
+         return homeData;
+      }
+
+      Optional<NaverPlaceData> menuData = apolloStateParser.parse(menuHtml, placeId);
+      if (menuData.isPresent()) {
+         return menuData;
+      }
+      return homeData;
+   }
+
+   private RestaurantInfoExtractor.NaverPlaceBasicInfo mergeBasicInfo(
+           Optional<NaverPlaceData> apolloData,
+           RestaurantInfoExtractor.NaverPlaceBasicInfo domData
+   ) {
+      if (apolloData.isEmpty()) {
+         return domData;
+      }
+
+      NaverPlaceData apollo = apolloData.get();
+      return new RestaurantInfoExtractor.NaverPlaceBasicInfo(
+              firstNonBlank(apollo.placeName(), domData.placeName()),
+              firstNonBlank(apollo.category(), domData.category()),
+              firstNonBlank(apollo.restaurantAddress(), domData.restaurantAddress()),
+              firstNonBlank(apollo.phoneNumber(), domData.phoneNumber()),
+              firstNonNull(apollo.latitude(), domData.latitude()),
+              firstNonNull(apollo.longitude(), domData.longitude()),
+              firstNonBlank(apollo.imageUrl(), domData.imageUrl())
+      );
+   }
+
+   private boolean usesDomBasicFallback(
+           Optional<NaverPlaceData> apolloData,
+           RestaurantInfoExtractor.NaverPlaceBasicInfo domData
+   ) {
+      if (apolloData.isEmpty()) {
+         return true;
+      }
+      NaverPlaceData apollo = apolloData.get();
+      return (isBlank(apollo.placeName()) && !isBlank(domData.placeName()))
+              || (isBlank(apollo.category()) && !isBlank(domData.category()))
+              || (isBlank(apollo.restaurantAddress()) && !isBlank(domData.restaurantAddress()))
+              || (isBlank(apollo.phoneNumber()) && !isBlank(domData.phoneNumber()))
+              || (apollo.latitude() == null && domData.latitude() != null)
+              || (apollo.longitude() == null && domData.longitude() != null)
+              || (isBlank(apollo.imageUrl()) && !isBlank(domData.imageUrl()));
+   }
+
+   private String firstNonBlank(String primary, String fallback) {
+      return isBlank(primary) ? fallback : primary;
+   }
+
+   private <T> T firstNonNull(T primary, T fallback) {
+      return primary == null ? fallback : primary;
    }
 
    private boolean shouldRetryWithBackoff(RestaurantRaw result, int attempt) {
@@ -237,7 +341,8 @@ public class RestaurantSingleCrawler {
             if (html.contains("GHAhO")
                     || html.contains("lnJFt")
                     || html.contains("og:title")
-                    || html.contains("PIbes")) {
+                    || html.contains("PIbes")
+                    || html.contains("window.__APOLLO_STATE__")) {
                return;
             }
             lastObserved = html;
@@ -312,6 +417,7 @@ public class RestaurantSingleCrawler {
       return html.contains("GHAhO")
               || html.contains("lnJFt")
               || html.contains("PIbes")
+              || html.contains("window.__APOLLO_STATE__")
               || html.contains("og:title")
               || html.contains("address")
               || html.contains("restaurant");

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverCaptchaDetector.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverCaptchaDetector.java
@@ -1,0 +1,25 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NaverCaptchaDetector {
+
+   private static final String CAPTCHA_ROOT_SELECTOR = "#wtm-captcha-root";
+   private static final String CAPTCHA_DIALOG_SELECTOR = "[role='dialog'][aria-label='보안 인증 필요']";
+
+   public boolean isDetected(Page page) {
+      return isVisible(page, CAPTCHA_ROOT_SELECTOR) || isVisible(page, CAPTCHA_DIALOG_SELECTOR);
+   }
+
+   private boolean isVisible(Page page, String selector) {
+      try {
+         Locator locator = page.locator(selector);
+         return locator.count() > 0 && locator.first().isVisible();
+      } catch (Exception ignored) {
+         return false;
+      }
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverCaptchaRequiredException.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverCaptchaRequiredException.java
@@ -1,0 +1,24 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+public class NaverCaptchaRequiredException extends RuntimeException {
+   private final int gridRow;
+   private final int gridCol;
+
+   public NaverCaptchaRequiredException(int gridRow, int gridCol) {
+      super("네이버 보안 인증이 필요합니다. grid=" + gridRow + "," + gridCol);
+      this.gridRow = gridRow;
+      this.gridCol = gridCol;
+   }
+
+   public int gridRow() {
+      return gridRow;
+   }
+
+   public int gridCol() {
+      return gridCol;
+   }
+
+   public String grid() {
+      return gridRow + "," + gridCol;
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverGridDiscoveryException.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverGridDiscoveryException.java
@@ -1,0 +1,7 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+public class NaverGridDiscoveryException extends RuntimeException {
+   public NaverGridDiscoveryException(int gridRow, int gridCol, Throwable cause) {
+      super("네이버 지도 그리드 수집에 실패했습니다. grid=" + gridRow + "," + gridCol, cause);
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlCheckpoint.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlCheckpoint.java
@@ -1,0 +1,38 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+final class ZoneCrawlCheckpoint {
+   private final LinkedHashSet<String> discoveredPlaceIds = new LinkedHashSet<>();
+   private int nextGridIndex;
+
+   synchronized int nextGridIndex() {
+      return nextGridIndex;
+   }
+
+   synchronized int discoveredPlaceCount() {
+      return discoveredPlaceIds.size();
+   }
+
+   synchronized void completeGrid(int completedGridIndex, Set<String> foundPlaceIds, int maxPlaceIds) {
+      if (completedGridIndex != nextGridIndex) {
+         throw new IllegalStateException(
+                 "체크포인트 그리드 순서가 일치하지 않습니다. expected="
+                         + nextGridIndex + ", actual=" + completedGridIndex
+         );
+      }
+
+      for (String placeId : foundPlaceIds) {
+         discoveredPlaceIds.add(placeId);
+         if (discoveredPlaceIds.size() >= maxPlaceIds) {
+            break;
+         }
+      }
+      nextGridIndex++;
+   }
+
+   synchronized Set<String> discoveredPlaceIdsSnapshot() {
+      return new LinkedHashSet<>(discoveredPlaceIds);
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlDefaults.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlDefaults.java
@@ -1,0 +1,10 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+final class ZoneCrawlDefaults {
+   static final double LAT_STEP = 0.0014;
+   static final double LNG_STEP = 0.0028;
+   static final int ZOOM = 19;
+
+   private ZoneCrawlDefaults() {
+   }
+}

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlJobService.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlJobService.java
@@ -6,7 +6,7 @@ import com.kustaurant.restaurantSync.sync.ZoneCrawlJobResultsPayload;
 import com.kustaurant.restaurantSync.sync.CrawlJobIdResponse;
 import com.kustaurant.restaurantSync.sync.ZoneCrawlStatusPayload;
 import com.kustaurant.restaurantSync.sync.ZoneCrawlResultPayload;
-import com.kustaurant.restaurantSync.sync.ZoneJCrawlobStatus;
+import com.kustaurant.restaurantSync.sync.ZoneCrawlJobStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,6 +17,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,16 @@ public class ZoneCrawlJobService {
 
    private final ZoneCrawler zoneCrawler;
    private final Map<String, ZoneCrawlJobState> jobs = new ConcurrentHashMap<>();
-   private final ExecutorService executor = Executors.newCachedThreadPool();
+   private final ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+      Thread thread = new Thread(runnable, "naver-zone-crawl-worker");
+      thread.setDaemon(true);
+      return thread;
+   });
+
+   @PreDestroy
+   void shutdownExecutor() {
+      executor.shutdownNow();
+   }
 
    public CrawlJobIdResponse start(ZoneType crawlScope) {
       String jobId = UUID.randomUUID().toString();
@@ -44,6 +54,24 @@ public class ZoneCrawlJobService {
       return Optional.ofNullable(jobs.get(jobId)).map(ZoneCrawlJobState::toStatusResponse);
    }
 
+   public Optional<CrawlJobIdResponse> resume(String jobId) {
+      ZoneCrawlJobState state = jobs.get(jobId);
+      if (state == null) {
+         return Optional.empty();
+      }
+
+      state.markResumeQueued();
+      executor.submit(() -> runJob(state));
+      log.info(
+              "구역 크롤 작업 재개 제출. jobId={}, scope={}, nextGridIndex={}, preservedPlaceCount={}",
+              jobId,
+              state.crawlScope,
+              state.checkpoint.nextGridIndex(),
+              state.checkpoint.discoveredPlaceCount()
+      );
+      return Optional.of(new CrawlJobIdResponse(jobId));
+   }
+
    public Optional<ZoneCrawlJobResultsPayload> getResults(String jobId, int fromIndex, int limit) {
       return Optional.ofNullable(jobs.get(jobId)).map(state -> state.toResultsResponse(fromIndex, limit));
    }
@@ -51,7 +79,7 @@ public class ZoneCrawlJobService {
    private void runJob(ZoneCrawlJobState state) {
       state.markRunning();
       try {
-         ZoneCrawlResultPayload result = zoneCrawler.crawlByScope(state.crawlScope, progress -> {
+         ZoneCrawlResultPayload result = zoneCrawler.crawlByScope(state.crawlScope, state.checkpoint, progress -> {
             state.currentPhase = progress.phase();
             state.totalGridCount = progress.totalGridCount();
             state.processedGridCount = progress.processedGridCount();
@@ -75,6 +103,16 @@ public class ZoneCrawlJobService {
                  result.discoveredPlaceCount(),
                  result.successCount()
          );
+      } catch (NaverCaptchaRequiredException e) {
+         state.markCaptchaRequired(e);
+         log.warn(
+                 "구역 크롤 작업 보안 인증 대기. jobId={}, scope={}, grid={}, preservedGridCount={}, preservedPlaceCount={}",
+                 state.jobId,
+                 state.crawlScope,
+                 e.grid(),
+                 state.checkpoint.nextGridIndex(),
+                 state.checkpoint.discoveredPlaceCount()
+         );
       } catch (Exception e) {
          state.markFailed(e);
          log.warn(
@@ -90,8 +128,9 @@ public class ZoneCrawlJobService {
    private static final class ZoneCrawlJobState {
       private final String jobId;
       private final ZoneType crawlScope;
+      private final ZoneCrawlCheckpoint checkpoint = new ZoneCrawlCheckpoint();
 
-      private volatile ZoneJCrawlobStatus status;
+      private volatile ZoneCrawlJobStatus status;
       private volatile String currentPhase;
       private volatile int totalGridCount;
       private volatile int processedGridCount;
@@ -112,7 +151,7 @@ public class ZoneCrawlJobService {
       private ZoneCrawlJobState(String jobId, ZoneType crawlScope) {
          this.jobId = jobId;
          this.crawlScope = crawlScope;
-         this.status = ZoneJCrawlobStatus.PENDING;
+         this.status = ZoneCrawlJobStatus.PENDING;
       }
 
       private static ZoneCrawlJobState pending(String jobId, ZoneType crawlScope) {
@@ -120,20 +159,44 @@ public class ZoneCrawlJobService {
       }
 
       private void markRunning() {
-         this.status = ZoneJCrawlobStatus.RUNNING;
+         this.status = ZoneCrawlJobStatus.RUNNING;
          this.currentPhase = "CRAWL_START";
-         this.startedAt = LocalDateTime.now();
+         this.errorMessage = null;
+         this.finishedAt = null;
+         if (this.startedAt == null) {
+            this.startedAt = LocalDateTime.now();
+         }
+      }
+
+      private synchronized void markResumeQueued() {
+         if (status != ZoneCrawlJobStatus.CAPTCHA_REQUIRED) {
+            throw new IllegalStateException(
+                    "보안 인증 대기 상태의 작업만 재개할 수 있습니다. status=" + status
+            );
+         }
+         this.status = ZoneCrawlJobStatus.RUNNING;
+         this.currentPhase = "RESUME_QUEUED";
+         this.errorMessage = null;
+         this.finishedAt = null;
+      }
+
+      private void markCaptchaRequired(NaverCaptchaRequiredException e) {
+         this.status = ZoneCrawlJobStatus.CAPTCHA_REQUIRED;
+         this.currentPhase = "CAPTCHA_REQUIRED";
+         this.currentGrid = e.grid();
+         this.errorMessage = e.getMessage();
+         this.finishedAt = null;
       }
 
       private void markSuccess(ZoneCrawlResultPayload result) {
          this.result = result;
-         this.status = ZoneJCrawlobStatus.SUCCESS;
+         this.status = ZoneCrawlJobStatus.SUCCESS;
          this.currentPhase = "COMPLETED";
          this.finishedAt = LocalDateTime.now();
       }
 
       private void markFailed(Exception e) {
-         this.status = ZoneJCrawlobStatus.FAILED;
+         this.status = ZoneCrawlJobStatus.FAILED;
          this.errorMessage = e.getMessage();
          this.finishedAt = LocalDateTime.now();
       }

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlProgress.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlProgress.java
@@ -1,7 +1,6 @@
 package com.kustaurant.crawler.RestaurantSync.service.zone;
 
 import com.kustaurant.restaurantSync.RestaurantRaw;
-
 import java.util.List;
 
 public record ZoneCrawlProgress(

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawler.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawler.java
@@ -2,6 +2,7 @@ package com.kustaurant.crawler.RestaurantSync.service.zone;
 
 import com.kustaurant.crawler.RestaurantSync.CrawlGrid;
 import com.kustaurant.crawler.RestaurantSync.GridGenerator;
+import com.kustaurant.crawler.infrastructure.crawler.playwright.PlaywrightManager;
 import com.kustaurant.crawler.RestaurantSync.service.single.RestaurantSingleCrawler;
 import com.kustaurant.map.ZonePolygon;
 import com.kustaurant.map.ZoneType;
@@ -11,64 +12,126 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ZoneCrawler {
-   private static final double DEFAULT_LAT_STEP = 0.0014;
-   private static final double DEFAULT_LNG_STEP = 0.0028;
-   private static final int DEFAULT_ZOOM = 19;
-   private static final int MAX_PLACE_IDS = Integer.MAX_VALUE;
-   private static final long INTER_PLACE_DELAY_MIN_MS = 3_000L;
-   private static final long INTER_PLACE_DELAY_MAX_MS = 5_000L;
-
+   private final PlaywrightManager playwrightManager;
    private final RestaurantSingleCrawler restaurantSingleCrawler;
    private final ZonePlaceIdCollector zonePlaceIdCollector;
    private final ZoneResultPolicy zoneResultPolicy;
+
+   @Value("${crawler.naver-place.max-grids:2147483647}")
+   private int maxGrids = Integer.MAX_VALUE;
+
+   @Value("${crawler.naver-place.max-place-ids:2147483647}")
+   private int maxPlaceIds = Integer.MAX_VALUE;
 
    public ZoneCrawlResultPayload crawlByScope(
            ZoneType crawlScope,
            Consumer<ZoneCrawlProgress> progressListener
    ) {
+      return crawlByScope(crawlScope, new ZoneCrawlCheckpoint(), progressListener);
+   }
+
+   ZoneCrawlResultPayload crawlByScope(
+           ZoneType crawlScope,
+           ZoneCrawlCheckpoint checkpoint,
+           Consumer<ZoneCrawlProgress> progressListener
+   ) {
+      return playwrightManager.withReusableBrowser(
+              () -> crawlByScopeWithReusableBrowser(crawlScope, checkpoint, progressListener)
+      );
+   }
+
+   private ZoneCrawlResultPayload crawlByScopeWithReusableBrowser(
+           ZoneType crawlScope,
+           ZoneCrawlCheckpoint checkpoint,
+           Consumer<ZoneCrawlProgress> progressListener
+   ) {
       ZonePolygon zone = zoneResultPolicy.findZonePolygon(crawlScope)
               .orElseThrow(() -> new IllegalArgumentException("Unsupported crawl scope: " + crawlScope));
 
-      List<CrawlGrid> grids = GridGenerator.generate(zone, DEFAULT_LAT_STEP, DEFAULT_LNG_STEP);
+      List<CrawlGrid> generatedGrids = GridGenerator.generate(
+              zone,
+              ZoneCrawlDefaults.LAT_STEP,
+              ZoneCrawlDefaults.LNG_STEP
+      );
+      int gridLimit = Math.max(1, Math.min(maxGrids, generatedGrids.size()));
+      List<CrawlGrid> grids = List.copyOf(generatedGrids.subList(0, gridLimit));
       log.info(
               "구역 크롤 시작. scope={}, zoneType={}, gridCount={}, latStep={}, lngStep={}, zoom={}",
               crawlScope,
               zone.zoneType(),
               grids.size(),
-              DEFAULT_LAT_STEP,
-              DEFAULT_LNG_STEP,
-              DEFAULT_ZOOM
+              ZoneCrawlDefaults.LAT_STEP,
+              ZoneCrawlDefaults.LNG_STEP,
+              ZoneCrawlDefaults.ZOOM
       );
 
-      Set<String> placeIds = zonePlaceIdCollector.discoverPlaceIds(
-              grids,
-              DEFAULT_ZOOM,
-              MAX_PLACE_IDS,
-              progress -> progressListener.accept(new ZoneCrawlProgress(
-                      "DISCOVERING",
-                      grids.size(),
-                      progress.processedGridCount(),
-                      progress.discoveredPlaceCount(),
-                      0,
-                      0,
-                      0,
-                      0,
-                      List.of(),
-                      null,
-                      progress.currentGrid(),
-                      null
-              ))
-      );
+      int placeIdLimit = Math.max(1, maxPlaceIds);
+      int resumeGridIndex = checkpoint.nextGridIndex();
+      if (resumeGridIndex > grids.size()) {
+         throw new IllegalStateException(
+                 "체크포인트가 현재 그리드 범위를 벗어났습니다. nextGridIndex="
+                         + resumeGridIndex + ", gridCount=" + grids.size()
+         );
+      }
+
+      if (resumeGridIndex > 0) {
+         log.info(
+                 "구역 크롤 체크포인트 재개. scope={}, nextGridIndex={}, preservedPlaceCount={}",
+                 crawlScope,
+                 resumeGridIndex,
+                 checkpoint.discoveredPlaceCount()
+         );
+      }
+
+      for (int gridIndex = resumeGridIndex; gridIndex < grids.size(); gridIndex++) {
+         if (checkpoint.discoveredPlaceCount() >= placeIdLimit) {
+            break;
+         }
+
+         CrawlGrid grid = grids.get(gridIndex);
+         Set<String> found = zonePlaceIdCollector.discoverPlaceIdsFromGrid(grid, ZoneCrawlDefaults.ZOOM);
+         int before = checkpoint.discoveredPlaceCount();
+         checkpoint.completeGrid(gridIndex, found, placeIdLimit);
+         int after = checkpoint.discoveredPlaceCount();
+
+         log.info(
+                 "그리드 체크포인트 저장. scope={}, row={}, col={}, found={}, added={}, duplicate={}, total={}",
+                 crawlScope,
+                 grid.row(),
+                 grid.col(),
+                 found.size(),
+                 after - before,
+                 found.size() - (after - before),
+                 after
+         );
+
+         progressListener.accept(new ZoneCrawlProgress(
+                 "DISCOVERING",
+                 grids.size(),
+                 checkpoint.nextGridIndex(),
+                 checkpoint.discoveredPlaceCount(),
+                 0,
+                 0,
+                 0,
+                 0,
+                 List.of(),
+                 null,
+                 grid.row() + "," + grid.col(),
+                 null
+         ));
+      }
+
+      Set<String> placeIds = checkpoint.discoveredPlaceIdsSnapshot();
 
       List<RestaurantRaw> results = new ArrayList<>();
       Set<String> retryQueue = new LinkedHashSet<>();
@@ -80,7 +143,7 @@ public class ZoneCrawler {
          progressListener.accept(new ZoneCrawlProgress(
                  "CRAWLING",
                  grids.size(),
-                 grids.size(),
+                 checkpoint.nextGridIndex(),
                  placeIds.size(),
                  placeIds.size(),
                  crawlAttempt,
@@ -117,7 +180,7 @@ public class ZoneCrawler {
             progressListener.accept(new ZoneCrawlProgress(
                     "CRAWLING",
                     grids.size(),
-                    grids.size(),
+                    checkpoint.nextGridIndex(),
                     placeIds.size(),
                     placeIds.size(),
                     crawlAttempt,
@@ -131,8 +194,6 @@ public class ZoneCrawler {
          } catch (Exception e) {
             retryQueue.add(placeId);
             log.warn("구역 크롤 상세 수집 실패. placeId={}, scope={}", placeId, crawlScope, e);
-         } finally {
-            sleepMillis(randomInterPlaceDelayMs());
          }
       }
 
@@ -145,7 +206,7 @@ public class ZoneCrawler {
             progressListener.accept(new ZoneCrawlProgress(
                     "RETRYING",
                     grids.size(),
-                    grids.size(),
+                    checkpoint.nextGridIndex(),
                     placeIds.size(),
                     totalWithRetry,
                     crawlAttempt,
@@ -182,7 +243,7 @@ public class ZoneCrawler {
                progressListener.accept(new ZoneCrawlProgress(
                        "RETRYING",
                        grids.size(),
-                       grids.size(),
+                       checkpoint.nextGridIndex(),
                        placeIds.size(),
                        totalWithRetry,
                        crawlAttempt,
@@ -196,8 +257,6 @@ public class ZoneCrawler {
             } catch (Exception e) {
                finalFailedPlaceIds.add(placeId);
                log.warn("2차 리트라이 예외 최종실패. scope={}, placeId={}", crawlScope, placeId, e);
-            } finally {
-               sleepMillis(randomInterPlaceDelayMs());
             }
          }
       }
@@ -205,7 +264,7 @@ public class ZoneCrawler {
       progressListener.accept(new ZoneCrawlProgress(
               "COMPLETED",
               grids.size(),
-              grids.size(),
+              checkpoint.nextGridIndex(),
               placeIds.size(),
               placeIds.size() + retryQueue.size(),
               crawlAttempt,
@@ -220,31 +279,4 @@ public class ZoneCrawler {
       return new ZoneCrawlResultPayload(placeIds.size(), results.size(), results);
    }
 
-   private long randomInterPlaceDelayMs() {
-      return ThreadLocalRandom.current().nextLong(INTER_PLACE_DELAY_MIN_MS, INTER_PLACE_DELAY_MAX_MS + 1);
-   }
-
-   private void sleepMillis(long millis) {
-      try {
-         Thread.sleep(millis);
-      } catch (InterruptedException e) {
-         Thread.currentThread().interrupt();
-      }
-   }
-
-   public record ZoneCrawlProgress(
-           String phase,
-           int totalGridCount,
-           int processedGridCount,
-           int discoveredPlaceCount,
-           int totalPlaceCount,
-           int attemptedPlaceCount,
-           int crawledSuccessCount,
-           int finalFailedCount,
-           List<String> finalFailedPlaceIds,
-           RestaurantRaw acceptedResult,
-           String currentGrid,
-           String currentPlaceId
-   ) {
-   }
 }

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZonePlaceIdCollector.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZonePlaceIdCollector.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -34,89 +33,48 @@ public class ZonePlaceIdCollector {
    private static final long GRID_RETRY_JITTER_MAX_MS = 1_000L;
 
    private final PlaywrightManager playwrightManager;
-
-   public Set<String> discoverPlaceIds(
-           Iterable<CrawlGrid> grids,
-           int zoom,
-           int maxPlaceIds,
-           Consumer<GridDiscoveryProgress> progressListener
-   ) {
-      Set<String> placeIds = new LinkedHashSet<>();
-      int gridIndex = 0;
-
-      for (CrawlGrid grid : grids) {
-         gridIndex++;
-
-         if (placeIds.size() >= maxPlaceIds) {
-            log.info(
-                    "구역 크롤 placeId 수집 최대치 도달. processedGrids={}, discoveredPlaceCount={}",
-                    gridIndex - 1,
-                    placeIds.size()
-            );
-            break;
-         }
-
-         Set<String> found = discoverPlaceIdsFromGrid(grid, zoom);
-
-         int before = placeIds.size();
-         for (String id : found) {
-            placeIds.add(id);
-            if (placeIds.size() >= maxPlaceIds) {
-               break;
-            }
-         }
-
-         int after = placeIds.size();
-         int added = after - before;
-         int duplicate = found.size() - added;
-
-         log.info(
-                 "그리드 처리 완료. row={}, col={}, found={}, added={}, duplicate={}, total={}",
-                 grid.row(),
-                 grid.col(),
-                 found.size(),
-                 added,
-                 duplicate,
-                 after
-         );
-
-         progressListener.accept(new GridDiscoveryProgress(
-                 gridIndex,
-                 placeIds.size(),
-                 grid.row() + "," + grid.col()
-         ));
-      }
-
-      return placeIds;
-   }
+   private final NaverCaptchaDetector captchaDetector;
 
    public Set<String> discoverPlaceIdsFromGrid(CrawlGrid grid, int zoom) {
       for (int attempt = 1; attempt <= GRID_DISCOVERY_MAX_ATTEMPTS; attempt++) {
          try {
             return playwrightManager.crawl(page -> discoverPlaceIdsFromGridOnce(page, grid, zoom));
          } catch (Exception e) {
-            boolean retryable = isRetryableSearchIframeFailure(e);
+            boolean captchaDetected = isCaptchaFailure(e);
             boolean hasNextAttempt = attempt < GRID_DISCOVERY_MAX_ATTEMPTS;
             log.warn(
-                    "그리드 목록 placeId 수집 실패. grid({},{}), attempt={}/{}, retryable={}, reason={}",
+                    "그리드 목록 placeId 수집 실패. grid({},{}), attempt={}/{}, captcha={}, willRetry={}, reason={}",
                     grid.row(),
                     grid.col(),
                     attempt,
                     GRID_DISCOVERY_MAX_ATTEMPTS,
-                    retryable && hasNextAttempt,
+                    captchaDetected,
+                    !captchaDetected && hasNextAttempt,
                     e.getMessage(),
                     e
             );
 
-            if (!(retryable && hasNextAttempt)) {
-               return Set.of();
+            if (captchaDetected) {
+               log.warn(
+                       "네이버 보안 인증 감지. 자동 재시도 없이 작업을 일시정지합니다. grid=({}, {})",
+                       grid.row(), grid.col()
+               );
+               throw new NaverCaptchaRequiredException(grid.row(), grid.col());
+            }
+
+            if (!hasNextAttempt) {
+               throw new NaverGridDiscoveryException(grid.row(), grid.col(), e);
             }
 
             sleepMillis(retryDelayMillis(attempt));
          }
       }
 
-      return Set.of();
+      throw new NaverGridDiscoveryException(
+              grid.row(),
+              grid.col(),
+              new IllegalStateException("그리드 재시도 횟수를 소진했습니다.")
+      );
    }
 
    private Set<String> discoverPlaceIdsFromGridOnce(Page page, CrawlGrid grid, int zoom) {
@@ -141,15 +99,19 @@ public class ZonePlaceIdCollector {
       page.navigate(mapUrl, new Page.NavigateOptions().setTimeout(30_000));
       page.waitForLoadState(LoadState.DOMCONTENTLOADED);
       page.waitForTimeout(2_000);
+      throwIfCaptchaDetected(page, grid);
 
       moveMapToGridCenter(page, grid, zoom);
       page.waitForTimeout(1_000);
+      throwIfCaptchaDetected(page, grid);
 
       clickFoodCategoryButton(page);
       page.waitForTimeout(2_500);
+      throwIfCaptchaDetected(page, grid);
 
       waitForSearchIframe(page);
-      collectPlaceIdsByClickingList(page, collectedIds);
+      collectPlaceIdsByClickingList(page, collectedIds, grid);
+      throwIfCaptchaDetected(page, grid);
 
       log.info(
               "그리드 목록 placeId 수집 완료. row={}, col={}, collectedCount={}, currentUrl={}",
@@ -162,7 +124,7 @@ public class ZonePlaceIdCollector {
       return collectedIds;
    }
 
-   private void collectPlaceIdsByClickingList(Page page, Set<String> collector) {
+   private void collectPlaceIdsByClickingList(Page page, Set<String> collector, CrawlGrid grid) {
       Frame searchFrame = getSearchFrameOrThrow(page);
       waitForInitialListReady(page, searchFrame);
 
@@ -170,12 +132,14 @@ public class ZonePlaceIdCollector {
       int stableRounds = 0;
 
       for (int round = 0; round < 30; round++) {
+         throwIfCaptchaDetected(page, grid);
          Locator items = searchFrame.locator(LIST_ITEM_SELECTOR);
          int currentCount = items.count();
 
          if (currentCount > lastProcessedIndex) {
             for (int i = lastProcessedIndex; i < currentCount; i++) {
                try {
+                  throwIfCaptchaDetected(page, grid);
                   Locator item = items.nth(i);
 
                   String placeName = extractPlaceName(item);
@@ -198,6 +162,9 @@ public class ZonePlaceIdCollector {
                   });
                   page.waitForTimeout(120);
                } catch (Exception e) {
+                  if (isCaptchaFailure(e) || captchaDetector.isDetected(page)) {
+                     throw new NaverCaptchaRequiredException(grid.row(), grid.col());
+                  }
                   log.warn("목록 아이템 클릭 실패. index={}, reason={}", i, e.getMessage());
                }
             }
@@ -407,11 +374,20 @@ public class ZonePlaceIdCollector {
       }
    }
 
-   private boolean isRetryableSearchIframeFailure(Exception e) {
-      Throwable current = e;
+   private void throwIfCaptchaDetected(Page page, CrawlGrid grid) {
+      if (captchaDetector.isDetected(page)) {
+         throw new NaverCaptchaRequiredException(grid.row(), grid.col());
+      }
+   }
+
+   private boolean isCaptchaFailure(Throwable error) {
+      Throwable current = error;
       while (current != null) {
+         if (current instanceof NaverCaptchaRequiredException) {
+            return true;
+         }
          String message = current.getMessage();
-         if (message != null && message.contains("search iframe not found")) {
+         if (message != null && (message.contains("wtm-captcha-root") || message.contains("보안 인증 필요"))) {
             return true;
          }
          current = current.getCause();
@@ -433,10 +409,4 @@ public class ZonePlaceIdCollector {
       }
    }
 
-   public record GridDiscoveryProgress(
-           int processedGridCount,
-           int discoveredPlaceCount,
-           String currentGrid
-   ) {
-   }
 }

--- a/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneTestCrawler.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneTestCrawler.java
@@ -2,6 +2,7 @@ package com.kustaurant.crawler.RestaurantSync.service.zone;
 
 import com.kustaurant.crawler.RestaurantSync.CrawlGrid;
 import com.kustaurant.crawler.RestaurantSync.GridGenerator;
+import com.kustaurant.crawler.infrastructure.crawler.playwright.PlaywrightManager;
 import com.kustaurant.crawler.RestaurantSync.service.single.RestaurantSingleCrawler;
 import com.kustaurant.map.ZonePolygon;
 import com.kustaurant.map.ZoneType;
@@ -10,7 +11,6 @@ import com.kustaurant.restaurantSync.sync.ZoneCrawlResultPayload;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,33 +20,43 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ZoneTestCrawler {
 
-   private static final double DEFAULT_LAT_STEP = 0.0018;
-   private static final double DEFAULT_LNG_STEP = 0.0022;
-   private static final int DEFAULT_ZOOM = 19;
    private static final int MAX_CRAWL_COUNT = 10;
 
+   private final PlaywrightManager playwrightManager;
    private final RestaurantSingleCrawler restaurantSingleCrawler;
    private final ZonePlaceIdCollector zonePlaceIdCollector;
    private final ZoneResultPolicy zoneResultPolicy;
 
    public ZoneCrawlResultPayload testCrawl(ZoneType crawlScope) {
+      return playwrightManager.withReusableBrowser(() -> testCrawlWithReusableBrowser(crawlScope));
+   }
+
+   private ZoneCrawlResultPayload testCrawlWithReusableBrowser(ZoneType crawlScope) {
       ZonePolygon zone = zoneResultPolicy.findZonePolygon(crawlScope)
               .orElseThrow(() -> new IllegalArgumentException("Unsupported crawl scope: " + crawlScope));
 
-      List<CrawlGrid> grids = GridGenerator.generate(zone, DEFAULT_LAT_STEP, DEFAULT_LNG_STEP);
+      List<CrawlGrid> grids = GridGenerator.generate(
+              zone,
+              ZoneCrawlDefaults.LAT_STEP,
+              ZoneCrawlDefaults.LNG_STEP
+      );
       if (grids.isEmpty()) {
          return new ZoneCrawlResultPayload(0, 0, List.of());
       }
 
       CrawlGrid firstGrid = grids.get(0);
-      Set<String> collectedIds = zonePlaceIdCollector.discoverPlaceIdsFromGrid(firstGrid, DEFAULT_ZOOM);
+      Set<String> collectedIds = zonePlaceIdCollector.discoverPlaceIdsFromGrid(
+              firstGrid,
+              ZoneCrawlDefaults.ZOOM
+      );
       List<RestaurantRaw> results = new ArrayList<>();
 
-      int crawled = 0;
+      int attempted = 0;
       for (String placeId : collectedIds) {
-         if (crawled >= MAX_CRAWL_COUNT) {
+         if (attempted >= MAX_CRAWL_COUNT) {
             break;
          }
+         attempted++;
 
          String placeUrl = "https://map.naver.com/p/entry/place/" + placeId;
          try {
@@ -65,28 +75,14 @@ public class ZoneTestCrawler {
             if (!inside) continue;
 
             results.add(result);
-            crawled++;
          } catch (Exception e) {
             log.warn("단일 그리드 상세 크롤 실패. placeId={}", placeId, e);
-         } finally {
-            long delayMs = ThreadLocalRandom.current().nextLong(3_000, 5_001);
-            log.info(
-                    "식당 간 분석 랜덤 대기. placeId={}, waitSec={}",
-                    placeId,
-                    delayMs / 1000.0
-            );
-            try {
-               Thread.sleep(delayMs);
-            } catch (InterruptedException e) {
-               Thread.currentThread().interrupt();
-               break;
-            }
          }
       }
 
       log.info(
               "구역 테스트 크롤 종료. scope={}, discoveredPlaceCount={}, crawledSuccessCount={}, returnedResultCount={}",
-              crawlScope, collectedIds.size(), crawled, results.size()
+              crawlScope, collectedIds.size(), results.size(), results.size()
       );
 
       return new ZoneCrawlResultPayload(collectedIds.size(), results.size(), results);

--- a/server/crawler/src/main/java/com/kustaurant/crawler/infrastructure/crawler/playwright/PlaywrightManager.java
+++ b/server/crawler/src/main/java/com/kustaurant/crawler/infrastructure/crawler/playwright/PlaywrightManager.java
@@ -7,12 +7,16 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Semaphore;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 @Component
 public class PlaywrightManager {
    private static final double DEFAULT_TIMEOUT_MILLIS = 10000.0;
    private static final AtomicInteger ACTIVE_BROWSERS = new AtomicInteger(0);
+   private final ThreadLocal<ReusableBrowserSession> reusableSession = new ThreadLocal<>();
+   private final Semaphore browserPermit = new Semaphore(1, true);
 
    public PlaywrightManager(MeterRegistry registry) {
       Gauge.builder("playwright_active_browsers", ACTIVE_BROWSERS, AtomicInteger::get)
@@ -20,29 +24,79 @@ public class PlaywrightManager {
    }
 
    public <T> T crawl(Function<Page, T> function) {
+      ReusableBrowserSession session = reusableSession.get();
+      if (session != null) {
+         try (Page page = createPage(session.context())) {
+            return function.apply(page);
+         }
+      }
+
+      acquireBrowserPermit();
       ACTIVE_BROWSERS.incrementAndGet();
 
       try (Playwright pw = createPlaywright()) {
          try (Browser browser = createBrowser(pw)) {
-            try (Page page = createPage(browser)) {
-               return function.apply(page);
+            try (BrowserContext context = createContext(browser)) {
+               try (Page page = createPage(context)) {
+                  return function.apply(page);
+               }
             }
          }
       } finally {
          ACTIVE_BROWSERS.decrementAndGet();
+         browserPermit.release();
       }
    }
 
-   private static Page createPage(Browser browser) {
-      BrowserContext ctx = browser.newContext((new Browser.NewContextOptions())
+   public <T> T withReusableBrowser(Supplier<T> function) {
+      if (reusableSession.get() != null) {
+         return function.get();
+      }
+
+      acquireBrowserPermit();
+      ACTIVE_BROWSERS.incrementAndGet();
+      try (Playwright pw = createPlaywright()) {
+         try (Browser browser = createBrowser(pw)) {
+            try (BrowserContext context = createContext(browser)) {
+               reusableSession.set(new ReusableBrowserSession(context));
+               try {
+                  return function.get();
+               } finally {
+                  reusableSession.remove();
+               }
+            }
+         }
+      } finally {
+         ACTIVE_BROWSERS.decrementAndGet();
+         browserPermit.release();
+      }
+   }
+
+   private void acquireBrowserPermit() {
+      try {
+         browserPermit.acquire();
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         throw new IllegalStateException("Playwright 브라우저 실행 대기 중 인터럽트되었습니다.", e);
+      }
+   }
+
+   private static BrowserContext createContext(Browser browser) {
+      return browser.newContext((new Browser.NewContextOptions())
               .setViewportSize(3840, 2160)
               .setIsMobile(false)
               .setHasTouch(false)
               .setLocale("ko-KR")
               .setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0"));
-      Page page = ctx.newPage();
+   }
+
+   private static Page createPage(BrowserContext context) {
+      Page page = context.newPage();
       page.setDefaultTimeout(DEFAULT_TIMEOUT_MILLIS);
       return page;
+   }
+
+   private record ReusableBrowserSession(BrowserContext context) {
    }
 
    private static Playwright createPlaywright() {

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/NaverApolloStateParserTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/NaverApolloStateParserTest.java
@@ -1,0 +1,172 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class NaverApolloStateParserTest {
+
+   private final NaverApolloStateParser parser = new NaverApolloStateParser(new ObjectMapper());
+
+   @Test
+   void parsesPlaceAndMenusFromSerializedApolloCache() {
+      String html = """
+              <html><head><script>
+              window.__APOLLO_STATE__ = {
+                "PlaceDetailBase:1183785127": {
+                  "__typename": "PlaceDetailBase",
+                  "id": "1183785127",
+                  "name": "고베규카츠 건대점",
+                  "category": "돈가스",
+                  "address": "서울 광진구 화양동 3-73",
+                  "roadAddress": "서울 광진구 아차산로33길 64",
+                  "virtualPhone": "0507-1442-4620",
+                  "coordinate": {"__typename":"Coordinate","x":"127.0711644","y":"37.5430071"}
+                },
+                "Menu:1183785127_0": {
+                  "__typename": "Menu",
+                  "id": "1183785127_0",
+                  "name": "규카츠 정식",
+                  "price": "19000",
+                  "description": "중괄호 } 와 따옴표 \\"가 포함된 설명",
+                  "images": ["https://example.com/menu.jpg"]
+                },
+                "ROOT_QUERY": {
+                  "__typename": "Query",
+                  "placeDetail({\\\"input\\\":{\\\"id\\\":\\\"1183785127\\\"}})": {
+                    "__typename": "PlaceDetail",
+                    "base": {"__ref": "PlaceDetailBase:1183785127"},
+                    "phoneInfo": {"phone": "02-123-4567"},
+                    "images": {"images": [{"origin": "https://example.com/place.jpg"}]},
+                    "menus({\\\"source\\\":[\\\"tpirates\\\"]})": [
+                      {"__ref": "Menu:1183785127_0"}
+                    ]
+                  }
+                }
+              };
+              window.__PLACE_STATE__ = {"unrelated": true};
+              </script></head><body></body></html>
+              """;
+
+      var result = parser.parse(html, "1183785127");
+
+      assertThat(result).isPresent();
+      var data = result.orElseThrow();
+      assertThat(data.placeName()).isEqualTo("고베규카츠 건대점");
+      assertThat(data.category()).isEqualTo("돈가스");
+      assertThat(data.restaurantAddress()).isEqualTo("서울 광진구 아차산로33길 64");
+      assertThat(data.phoneNumber()).isEqualTo("02-123-4567");
+      assertThat(data.latitude()).isEqualTo(37.5430071);
+      assertThat(data.longitude()).isEqualTo(127.0711644);
+      assertThat(data.imageUrl()).isEqualTo("https://example.com/place.jpg");
+      assertThat(data.menuDataPresent()).isTrue();
+      assertThat(data.menus()).singleElement().satisfies(menu -> {
+         assertThat(menu.menuName()).isEqualTo("규카츠 정식");
+         assertThat(menu.menuPrice()).isEqualTo("19,000원");
+         assertThat(menu.menuImageUrl()).isEqualTo("https://example.com/menu.jpg");
+      });
+   }
+
+   @Test
+   void treatsAnExplicitEmptyMenuListAsAuthoritative() {
+      String html = """
+              <script>
+              window.__APOLLO_STATE__ = {
+                "PlaceDetailBase:42": {
+                  "__typename":"PlaceDetailBase", "id":"42", "name":"메뉴 없는 식당"
+                },
+                "ROOT_QUERY": {
+                  "placeDetail": {
+                    "__typename":"PlaceDetail",
+                    "base":{"__ref":"PlaceDetailBase:42"},
+                    "menus":[]
+                  }
+                }
+              };
+              </script>
+              """;
+
+      var data = parser.parse(html, "42").orElseThrow();
+
+      assertThat(data.menuDataPresent()).isTrue();
+      assertThat(data.menus()).isEmpty();
+   }
+
+   @Test
+   void preservesLegacyLabelsForFreeAndVariablePrices() {
+      String html = """
+              <script>
+              window.__APOLLO_STATE__ = {
+                "PlaceDetailBase:42": {
+                  "__typename":"PlaceDetailBase", "id":"42", "name":"가격 표기 식당"
+                },
+                "Menu:42_0": {
+                  "__typename":"Menu", "id":"42_0", "name":"무료 서비스", "price":"0"
+                },
+                "Menu:42_1": {
+                  "__typename":"Menu", "id":"42_1", "name":"시가 메뉴", "price":null
+                },
+                "ROOT_QUERY": {
+                  "placeDetail": {
+                    "__typename":"PlaceDetail",
+                    "base":{"__ref":"PlaceDetailBase:42"},
+                    "menus":[{"__ref":"Menu:42_0"},{"__ref":"Menu:42_1"}]
+                  }
+                }
+              };
+              </script>
+              """;
+
+      var data = parser.parse(html, "42").orElseThrow();
+
+      assertThat(data.menus()).extracting(menu -> menu.menuPrice())
+              .containsExactly("무료", "변동");
+   }
+
+   @Test
+   void ignoresApolloStateForAnotherPlace() {
+      String html = """
+              <script>
+              window.__APOLLO_STATE__ = {
+                "PlaceDetailBase:999": {
+                  "__typename":"PlaceDetailBase", "id":"999", "name":"다른 식당"
+                }
+              };
+              </script>
+              """;
+
+      assertThat(parser.parse(html, "42")).isEmpty();
+   }
+
+   @Test
+   void doesNotTreatBrokenMenuReferencesAsAuthoritative() {
+      String html = """
+              <script>
+              window.__APOLLO_STATE__ = {
+                "PlaceDetailBase:42": {
+                  "__typename":"PlaceDetailBase", "id":"42", "name":"참조 깨진 식당"
+                },
+                "ROOT_QUERY": {
+                  "placeDetail": {
+                    "__typename":"PlaceDetail",
+                    "base":{"__ref":"PlaceDetailBase:42"},
+                    "menus":[{"__ref":"Menu:42_missing"}]
+                  }
+                }
+              };
+              </script>
+              """;
+
+      var data = parser.parse(html, "42").orElseThrow();
+
+      assertThat(data.menuDataPresent()).isFalse();
+      assertThat(data.menus()).isEmpty();
+   }
+
+   @Test
+   void returnsEmptyWhenApolloStateIsMissingOrMalformed() {
+      assertThat(parser.parse("<html><body>일반 문서</body></html>", "42")).isEmpty();
+      assertThat(parser.parse("<script>window.__APOLLO_STATE__ = {</script>", "42")).isEmpty();
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantMenuDataResolverTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantMenuDataResolverTest.java
@@ -1,0 +1,49 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kustaurant.crawler.RestaurantSync.service.single.NaverApolloStateParser.NaverPlaceData;
+import com.kustaurant.restaurantSync.RestaurantRawMenu;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class RestaurantMenuDataResolverTest {
+   private final RestaurantMenuDataResolver resolver = new RestaurantMenuDataResolver();
+
+   @Test
+   void usesApolloMenusWhenTheMenuListIsAuthoritative() {
+      RestaurantRawMenu apolloMenu = new RestaurantRawMenu("Apollo 메뉴", "10,000원", null);
+      NaverPlaceData data = placeData(List.of(apolloMenu), true);
+
+      List<RestaurantRawMenu> result = resolver.resolve(
+              Optional.of(data),
+              () -> List.of(new RestaurantRawMenu("DOM 메뉴", "11,000원", null))
+      );
+
+      assertThat(result).containsExactly(apolloMenu);
+   }
+
+   @Test
+   void usesDomMenusWhenApolloOnlyContainsUnverifiedMenuEntities() {
+      RestaurantRawMenu cachedFragment = new RestaurantRawMenu("일부 캐시 메뉴", "10,000원", null);
+      RestaurantRawMenu domMenu = new RestaurantRawMenu("DOM 전체 메뉴", "11,000원", null);
+      AtomicBoolean domRead = new AtomicBoolean();
+      NaverPlaceData data = placeData(List.of(cachedFragment), false);
+
+      List<RestaurantRawMenu> result = resolver.resolve(Optional.of(data), () -> {
+         domRead.set(true);
+         return List.of(domMenu);
+      });
+
+      assertThat(domRead).isTrue();
+      assertThat(result).containsExactly(domMenu);
+   }
+
+   private NaverPlaceData placeData(List<RestaurantRawMenu> menus, boolean menuDataPresent) {
+      return new NaverPlaceData(
+              "테스트 식당", null, null, null, null, null, null, menus, menuDataPresent
+      );
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantResponseCollectorTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantResponseCollectorTest.java
@@ -1,0 +1,83 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.playwright.Response;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class RestaurantResponseCollectorTest {
+
+   private final RestaurantResponseCollector collector = new RestaurantResponseCollector();
+
+   @Test
+   void capturesInitialPlaceDocumentAsHomeHtml() {
+      Response response = htmlResponse(
+              "https://pcmap.place.naver.com/place/1183785127?entry=bmp&from=map",
+              "<script>window.__APOLLO_STATE__ = {}</script>"
+      );
+      AtomicReference<String> home = new AtomicReference<>();
+      AtomicReference<String> menu = new AtomicReference<>();
+
+      collector.captureHtmlResponse(response, "1183785127", home, menu, false);
+
+      assertThat(home.get()).contains("window.__APOLLO_STATE__");
+      assertThat(menu.get()).isNull();
+   }
+
+   @Test
+   void legacyModeIgnoresInitialPlaceDocument() {
+      Response response = htmlResponse(
+              "https://pcmap.place.naver.com/place/1183785127?entry=bmp&from=map",
+              "<script>window.__APOLLO_STATE__ = {}</script>"
+      );
+      AtomicReference<String> home = new AtomicReference<>();
+      AtomicReference<String> menu = new AtomicReference<>();
+
+      collector.captureHtmlResponse(response, "1183785127", home, menu, false, false);
+
+      assertThat(home.get()).isNull();
+      assertThat(menu.get()).isNull();
+   }
+
+   @Test
+   void capturesDirectRestaurantMenuDocument() {
+      Response response = htmlResponse(
+              "https://pcmap.place.naver.com/restaurant/1183785127/menu",
+              "<html><body><ul><li>규카츠 정식</li></ul></body></html>"
+      );
+      AtomicReference<String> home = new AtomicReference<>();
+      AtomicReference<String> menu = new AtomicReference<>();
+
+      collector.captureHtmlResponse(response, "1183785127", home, menu, false);
+
+      assertThat(home.get()).isNull();
+      assertThat(menu.get()).contains("규카츠 정식");
+   }
+
+   @Test
+   void ignoresLookalikePathsFromAnotherHost() {
+      Response response = htmlResponse(
+              "https://example.com/place/1183785127",
+              "<script>window.__APOLLO_STATE__ = {}</script>"
+      );
+      AtomicReference<String> home = new AtomicReference<>();
+      AtomicReference<String> menu = new AtomicReference<>();
+
+      collector.captureHtmlResponse(response, "1183785127", home, menu, false);
+
+      assertThat(home.get()).isNull();
+      assertThat(menu.get()).isNull();
+   }
+
+   private Response htmlResponse(String url, String body) {
+      Response response = mock(Response.class);
+      when(response.url()).thenReturn(url);
+      when(response.headers()).thenReturn(Map.of("content-type", "text/html; charset=utf-8"));
+      when(response.text()).thenReturn(body);
+      return response;
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantSingleCrawlerTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/RestaurantSingleCrawlerTest.java
@@ -1,0 +1,109 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kustaurant.crawler.RestaurantSync.service.zone.ZoneResultPolicy;
+import com.kustaurant.crawler.infrastructure.crawler.playwright.PlaywrightManager;
+import com.kustaurant.map.ZoneType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class RestaurantSingleCrawlerTest {
+
+   @Test
+   @SuppressWarnings("unchecked")
+   void usesApolloDataWithoutOpeningTheMenuPage() {
+      PlaywrightManager playwrightManager = mock(PlaywrightManager.class);
+      RestaurantPageDriver pageDriver = mock(RestaurantPageDriver.class);
+      RestaurantMenuExtractor menuExtractor = mock(RestaurantMenuExtractor.class);
+      ZoneResultPolicy zoneResultPolicy = mock(ZoneResultPolicy.class);
+      Page page = mock(Page.class);
+
+      RestaurantSingleCrawler crawler = new RestaurantSingleCrawler(
+              playwrightManager,
+              pageDriver,
+              new RestaurantResponseCollector(),
+              new NaverApolloStateParser(new ObjectMapper()),
+              new RestaurantInfoExtractor(),
+              menuExtractor,
+              new RestaurantMenuDataResolver(),
+              zoneResultPolicy
+      );
+
+      String placeUrl = "https://map.naver.com/p/entry/place/42";
+      String detailUrl = "https://pcmap.place.naver.com/place/42?entry=bmp&from=map";
+      String html = """
+              <script>
+              window.__APOLLO_STATE__ = {
+                "PlaceDetailBase:42": {
+                  "__typename":"PlaceDetailBase",
+                  "id":"42",
+                  "name":"Apollo 식당",
+                  "category":"한식",
+                  "roadAddress":"서울 광진구 테스트로 42",
+                  "virtualPhone":"0507-0000-0042",
+                  "coordinate":{"x":"127.1","y":"37.5"}
+                },
+                "Menu:42_0": {
+                  "__typename":"Menu", "id":"42_0", "name":"테스트 메뉴", "price":"12000", "images":[]
+                },
+                "ROOT_QUERY": {
+                  "placeDetail": {
+                    "__typename":"PlaceDetail",
+                    "base":{"__ref":"PlaceDetailBase:42"},
+                    "menus":[{"__ref":"Menu:42_0"}]
+                  }
+                }
+              };
+              </script>
+              """;
+
+      Response response = mock(Response.class);
+      when(response.url()).thenReturn(detailUrl);
+      when(response.headers()).thenReturn(Map.of("content-type", "text/html; charset=utf-8"));
+      when(response.text()).thenReturn(html);
+      when(page.url()).thenReturn(placeUrl);
+      when(page.frames()).thenReturn(List.of());
+      when(zoneResultPolicy.resolveZoneType(any())).thenReturn(ZoneType.OUT_OF_ZONE);
+
+      AtomicReference<Consumer<Response>> responseHandler = new AtomicReference<>();
+      org.mockito.Mockito.doAnswer(invocation -> {
+         responseHandler.set(invocation.getArgument(0));
+         return null;
+      }).when(page).onResponse(any());
+      org.mockito.Mockito.doAnswer(invocation -> {
+         responseHandler.get().accept(response);
+         return null;
+      }).when(pageDriver).openPlacePage(page, placeUrl);
+      when(playwrightManager.crawl(any())).thenAnswer(invocation -> {
+         Function<Page, ?> action = invocation.getArgument(0);
+         return action.apply(page);
+      });
+
+      var result = crawler.crawl(placeUrl);
+
+      assertThat(result.placeName()).isEqualTo("Apollo 식당");
+      assertThat(result.restaurantAddress()).isEqualTo("서울 광진구 테스트로 42");
+      assertThat(result.latitude()).isEqualTo(37.5);
+      assertThat(result.longitude()).isEqualTo(127.1);
+      assertThat(result.menus()).singleElement().satisfies(menu -> {
+         assertThat(menu.menuName()).isEqualTo("테스트 메뉴");
+         assertThat(menu.menuPrice()).isEqualTo("12,000원");
+      });
+      verify(pageDriver, never()).clickMenuTab(page);
+      verify(pageDriver, never()).navigateToDirectMenuIfNeeded(page, "42", false);
+      verify(menuExtractor, never()).extractMenus(any(), any());
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/ZoneDetailPerformanceBenchmarkTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/single/ZoneDetailPerformanceBenchmarkTest.java
@@ -1,0 +1,147 @@
+package com.kustaurant.crawler.RestaurantSync.service.single;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kustaurant.crawler.RestaurantSync.service.zone.ZoneResultPolicy;
+import com.kustaurant.crawler.infrastructure.crawler.playwright.PlaywrightManager;
+import com.kustaurant.map.ZoneType;
+import com.kustaurant.restaurantSync.RestaurantRaw;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "ZONE_DETAIL_BENCHMARK", matches = "true")
+class ZoneDetailPerformanceBenchmarkTest {
+   private static final Map<ZoneType, List<String>> PLACE_IDS = Map.of(
+           ZoneType.ENTRANCE_TO_MIDDLE, List.of(
+                   "1147316117", "1942535759", "1017400694", "1472207522", "11574647",
+                   "20502394", "1491159689", "1031081155", "1651919158", "1870282832"
+           ),
+           ZoneType.MIDDLE_TO_PARK, List.of(
+                   "1108218837", "1308720943", "1220429339", "36259116", "1717778616",
+                   "371256669", "1336548884", "1096868928", "1003680357", "1043470699"
+           ),
+           ZoneType.BACK_GATE, List.of(
+                   "1025538278", "1768962114", "1995275174", "1854582204", "1160743896",
+                   "1084941476", "1502246754", "1731256186", "1778931681", "1198483581"
+           ),
+           ZoneType.FRONT_GATE, List.of(
+                   "1680939918", "1426675615", "2076955322", "1690309548", "11717380",
+                   "2066467057", "38229720", "1645755407", "37211524", "37851081"
+           ),
+           ZoneType.GUI_STATION, List.of(
+                   "11489305", "1440507721", "2057162493", "1292962436", "1128282294",
+                   "1884031247", "1585565927", "11807283", "1452640597", "1808134871"
+           )
+   );
+
+   @Test
+   void comparesOriginalLegacyAndCurrentApolloDetailFlow() throws Exception {
+      PlaywrightManager manager = new PlaywrightManager(new SimpleMeterRegistry());
+      ZoneResultPolicy policy = new ZoneResultPolicy();
+      RestaurantSingleCrawler crawler = new RestaurantSingleCrawler(
+              manager,
+              new RestaurantPageDriver(),
+              new RestaurantResponseCollector(),
+              new NaverApolloStateParser(new ObjectMapper()),
+              new RestaurantInfoExtractor(),
+              new RestaurantMenuExtractor(),
+              new RestaurantMenuDataResolver(),
+              policy
+      );
+
+      ZoneType zone = ZoneType.valueOf(System.getenv("ZONE_DETAIL_BENCHMARK_SCOPE"));
+      List<String> ids = PLACE_IDS.get(zone);
+      BenchmarkResult legacy = runLegacy(crawler, policy, ids);
+      BenchmarkResult current = runCurrent(manager, crawler, policy, ids);
+
+      Map<String, Object> row = new LinkedHashMap<>();
+      row.put("zone", zone.name());
+      row.put("sampleCount", ids.size());
+      row.put("legacyDurationSeconds", legacy.durationSeconds());
+      row.put("legacyMeaningfulCount", legacy.meaningfulCount());
+      row.put("currentDurationSeconds", current.durationSeconds());
+      row.put("currentMeaningfulCount", current.meaningfulCount());
+      row.put("reductionPercent", round((legacy.durationSeconds() - current.durationSeconds())
+              / legacy.durationSeconds() * 100.0));
+      System.out.println("DETAIL_BENCHMARK=" + new ObjectMapper().writeValueAsString(row));
+
+      Path outputDirectory = Path.of("build", "benchmark");
+      Files.createDirectories(outputDirectory);
+      String runId = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+      Path output = outputDirectory.resolve("detail-" + zone + "-" + runId + ".json");
+      new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(output.toFile(), row);
+      System.out.println("DETAIL_BENCHMARK_OUTPUT=" + output.toAbsolutePath());
+
+      assertThat(row).containsEntry("sampleCount", 10);
+   }
+
+   private BenchmarkResult runLegacy(
+           RestaurantSingleCrawler crawler,
+           ZoneResultPolicy policy,
+           List<String> ids
+   ) throws Exception {
+      setMode(crawler, "LEGACY");
+      long started = System.nanoTime();
+      int meaningful = 0;
+      for (String id : ids) {
+         RestaurantRaw result = crawler.crawl(placeUrl(id));
+         if (policy.isMeaningfulResult(result)) meaningful++;
+         Thread.sleep(ThreadLocalRandom.current().nextLong(3_000L, 5_001L));
+      }
+      return new BenchmarkResult(elapsedSeconds(started), meaningful);
+   }
+
+   private BenchmarkResult runCurrent(
+           PlaywrightManager manager,
+           RestaurantSingleCrawler crawler,
+           ZoneResultPolicy policy,
+           List<String> ids
+   ) throws Exception {
+      setMode(crawler, "APOLLO_FIRST");
+      long started = System.nanoTime();
+      int meaningful = manager.withReusableBrowser(() -> {
+         int count = 0;
+         for (String id : ids) {
+            RestaurantRaw result = crawler.crawl(placeUrl(id));
+            if (policy.isMeaningfulResult(result)) count++;
+         }
+         return count;
+      });
+      return new BenchmarkResult(elapsedSeconds(started), meaningful);
+   }
+
+   @SuppressWarnings({"rawtypes", "unchecked"})
+   private void setMode(RestaurantSingleCrawler crawler, String mode) throws Exception {
+      Field field = RestaurantSingleCrawler.class.getDeclaredField("detailMode");
+      field.setAccessible(true);
+      Class<? extends Enum> enumType = (Class<? extends Enum>) field.getType();
+      field.set(crawler, Enum.valueOf(enumType, mode));
+   }
+
+   private String placeUrl(String id) {
+      return "https://map.naver.com/p/entry/place/" + id;
+   }
+
+   private double elapsedSeconds(long started) {
+      return round((System.nanoTime() - started) / 1_000_000_000.0);
+   }
+
+   private double round(double value) {
+      return Math.round(value * 1_000.0) / 1_000.0;
+   }
+
+   private record BenchmarkResult(double durationSeconds, int meaningfulCount) {
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverCaptchaDetectorTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/NaverCaptchaDetectorTest.java
@@ -1,0 +1,45 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import org.junit.jupiter.api.Test;
+
+class NaverCaptchaDetectorTest {
+
+   private final NaverCaptchaDetector detector = new NaverCaptchaDetector();
+
+   @Test
+   void detectsVisibleNaverCaptchaRoot() {
+      Page page = mock(Page.class);
+      Locator root = visibleLocator(true);
+      Locator dialog = visibleLocator(false);
+      when(page.locator("#wtm-captcha-root")).thenReturn(root);
+      when(page.locator("[role='dialog'][aria-label='보안 인증 필요']")).thenReturn(dialog);
+
+      assertThat(detector.isDetected(page)).isTrue();
+   }
+
+   @Test
+   void ignoresMissingOrHiddenCaptchaElements() {
+      Page page = mock(Page.class);
+      Locator root = visibleLocator(false);
+      Locator dialog = visibleLocator(false);
+      when(page.locator("#wtm-captcha-root")).thenReturn(root);
+      when(page.locator("[role='dialog'][aria-label='보안 인증 필요']")).thenReturn(dialog);
+
+      assertThat(detector.isDetected(page)).isFalse();
+   }
+
+   private Locator visibleLocator(boolean visible) {
+      Locator locator = mock(Locator.class);
+      Locator first = mock(Locator.class);
+      when(locator.count()).thenReturn(visible ? 1 : 0);
+      when(locator.first()).thenReturn(first);
+      when(first.isVisible()).thenReturn(visible);
+      return locator;
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlCheckpointTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlCheckpointTest.java
@@ -1,0 +1,38 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ZoneCrawlCheckpointTest {
+
+   @Test
+   void preservesOnlyCompletedGridsAndResumesAtNextGrid() {
+      ZoneCrawlCheckpoint checkpoint = new ZoneCrawlCheckpoint();
+
+      checkpoint.completeGrid(0, Set.of("101", "102"), 100);
+
+      assertThat(checkpoint.nextGridIndex()).isEqualTo(1);
+      assertThat(checkpoint.discoveredPlaceIdsSnapshot()).containsExactlyInAnyOrder("101", "102");
+
+      // 두 번째 그리드에서 캡차가 발생하면 completeGrid를 호출하지 않으므로 체크포인트는 그대로다.
+      assertThat(checkpoint.nextGridIndex()).isEqualTo(1);
+      assertThat(checkpoint.discoveredPlaceCount()).isEqualTo(2);
+
+      checkpoint.completeGrid(1, Set.of("102", "103"), 100);
+
+      assertThat(checkpoint.nextGridIndex()).isEqualTo(2);
+      assertThat(checkpoint.discoveredPlaceIdsSnapshot()).containsExactlyInAnyOrder("101", "102", "103");
+   }
+
+   @Test
+   void rejectsOutOfOrderGridCompletion() {
+      ZoneCrawlCheckpoint checkpoint = new ZoneCrawlCheckpoint();
+
+      assertThatThrownBy(() -> checkpoint.completeGrid(1, Set.of("101"), 100))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("expected=0, actual=1");
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlJobServiceConcurrencyTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZoneCrawlJobServiceConcurrencyTest.java
@@ -1,0 +1,48 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.kustaurant.map.ZoneType;
+import com.kustaurant.restaurantSync.sync.ZoneCrawlResultPayload;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ZoneCrawlJobServiceConcurrencyTest {
+
+   @Test
+   void runsOnlyOneZoneCrawlAtATime() throws Exception {
+      ZoneCrawler zoneCrawler = mock(ZoneCrawler.class);
+      AtomicInteger active = new AtomicInteger();
+      AtomicInteger maxActive = new AtomicInteger();
+      CountDownLatch completed = new CountDownLatch(2);
+
+      when(zoneCrawler.crawlByScope(any(), any(), any())).thenAnswer(invocation -> {
+         int current = active.incrementAndGet();
+         maxActive.accumulateAndGet(current, Math::max);
+         try {
+            Thread.sleep(100);
+            return new ZoneCrawlResultPayload(0, 0, List.of());
+         } finally {
+            active.decrementAndGet();
+            completed.countDown();
+         }
+      });
+
+      ZoneCrawlJobService service = new ZoneCrawlJobService(zoneCrawler);
+      try {
+         service.start(ZoneType.GUI_STATION);
+         service.start(ZoneType.BACK_GATE);
+
+         assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+         assertThat(maxActive).hasValue(1);
+      } finally {
+         service.shutdownExecutor();
+      }
+   }
+}

--- a/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZonePlaceIdCollectorFailureTest.java
+++ b/server/crawler/src/test/java/com/kustaurant/crawler/RestaurantSync/service/zone/ZonePlaceIdCollectorFailureTest.java
@@ -1,0 +1,55 @@
+package com.kustaurant.crawler.RestaurantSync.service.zone;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kustaurant.crawler.RestaurantSync.CrawlGrid;
+import com.kustaurant.crawler.infrastructure.crawler.playwright.PlaywrightManager;
+import com.kustaurant.map.ZoneType;
+import org.junit.jupiter.api.Test;
+
+class ZonePlaceIdCollectorFailureTest {
+
+   @Test
+   void pausesImmediatelyOnTheFirstCaptchaWithoutAutomaticRetry() {
+      PlaywrightManager playwrightManager = mock(PlaywrightManager.class);
+      ZonePlaceIdCollector collector = new ZonePlaceIdCollector(
+              playwrightManager,
+              mock(NaverCaptchaDetector.class)
+      );
+      when(playwrightManager.crawl(any())).thenThrow(new NaverCaptchaRequiredException(1, 2));
+
+      assertThatThrownBy(() -> collector.discoverPlaceIdsFromGrid(grid(1, 2), 19))
+              .isInstanceOf(NaverCaptchaRequiredException.class)
+              .hasMessageContaining("grid=1,2");
+      verify(playwrightManager, times(1)).crawl(any());
+   }
+
+   @Test
+   void throwsAfterRetriesInsteadOfReturningAnEmptySuccessfulGrid() {
+      PlaywrightManager playwrightManager = mock(PlaywrightManager.class);
+      ZonePlaceIdCollector collector = new ZonePlaceIdCollector(
+              playwrightManager,
+              mock(NaverCaptchaDetector.class)
+      );
+      when(playwrightManager.crawl(any())).thenThrow(new IllegalStateException("food category button not found"));
+
+      Thread.currentThread().interrupt();
+      try {
+         assertThatThrownBy(() -> collector.discoverPlaceIdsFromGrid(grid(0, 0), 19))
+                 .isInstanceOf(NaverGridDiscoveryException.class)
+                 .hasMessageContaining("grid=0,0");
+      } finally {
+         Thread.interrupted();
+      }
+      verify(playwrightManager, times(3)).crawl(any());
+   }
+
+   private CrawlGrid grid(int row, int col) {
+      return new CrawlGrid(ZoneType.GUI_STATION, row, col, 37.5, 127.0);
+   }
+}

--- a/server/kustaurant/build.gradle
+++ b/server/kustaurant/build.gradle
@@ -95,7 +95,7 @@ sourceSets {
     integrationTest { // 중형/통합 테스트
         java.srcDirs('src/integrationTest/java')
         resources.srcDirs('src/integrationTest/resources')
-        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+        compileClasspath += sourceSets.main.output
         runtimeClasspath += output + compileClasspath
     }
 }
@@ -106,33 +106,24 @@ configurations {
     integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
-// 실행 task 분리
-tasks.register('smallTest', Test) {
-    description = 'Run unit (small) tests'
-    group = 'verification'
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
+// 소형 테스트는 Gradle 표준 test task를 사용한다.
+tasks.named('test', Test) {
+    description = 'Run small tests'
     useJUnitPlatform()
-    reports.junitXml.outputLocation = layout.buildDirectory.dir("test-results/smallTest")
-    reports.html.outputLocation     = layout.buildDirectory.dir("reports/tests/smallTest")
 }
 
-tasks.register('middleTest', Test) {
-    description = 'Run integration (middle) tests'
+// 중형/통합 테스트는 integrationTest source set과 같은 이름의 task를 사용한다.
+tasks.register('integrationTest', Test) {
+    description = 'Run middle/integration tests'
     group = 'verification'
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     useJUnitPlatform()
-    reports.junitXml.outputLocation = layout.buildDirectory.dir("test-results/middleTest")
-    reports.html.outputLocation     = layout.buildDirectory.dir("reports/tests/middleTest")
+    shouldRunAfter tasks.named('test')
 }
 
-tasks.named('test') { // 기본 test는 비활성화, 소형, 중형 개별 선택해서 해야함
-    enabled = false
-}
-
-tasks.named('check') { // check 시 둘 다 돌리고 싶으면
-    dependsOn tasks.named('smallTest'), tasks.named('middleTest')
+tasks.named('check') {
+    dependsOn tasks.named('integrationTest')
 }
 
 tasks.named('processIntegrationTestResources', Copy) {

--- a/server/kustaurant/src/integrationTest/resources/application-test.yml
+++ b/server/kustaurant/src/integrationTest/resources/application-test.yml
@@ -22,3 +22,6 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+
+crawler:
+  base-url: http://localhost:8081

--- a/server/kustaurant/src/integrationTest/resources/docker-java.properties
+++ b/server/kustaurant/src/integrationTest/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/controller/command/RestaurantCrawlController.java
+++ b/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/controller/command/RestaurantCrawlController.java
@@ -75,7 +75,20 @@ public class RestaurantCrawlController {
       return zoneCrawlJobService.start(request.crawlScope());
    }
 
-   // 6. 구역 크롤 해당 job 진행상태 조회
+   // 6. 보안 인증 대기 중인 구역 크롤 작업 재개
+   @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
+   @PostMapping({"/naver-place/crawl-zone/jobs/{jobId}/resume"})
+   public CrawlJobIdResponse resumeNaverPlaceZoneCrawlJob(@PathVariable String jobId) {
+      try {
+         return zoneCrawlJobService.resume(jobId).orElseThrow(
+                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "zone crawl job not found: " + jobId)
+         );
+      } catch (IllegalStateException e) {
+         throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage(), e);
+      }
+   }
+
+   // 7. 구역 크롤 해당 job 진행상태 조회
    @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
    @GetMapping({"/naver-place/crawl-zone/jobs/{jobId}"})
    public ZoneCrawlJobStatusResponse getNaverPlaceZoneCrawlJobStatus(

--- a/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/controller/dto/ZoneCrawlJobStatusResponse.java
+++ b/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/controller/dto/ZoneCrawlJobStatusResponse.java
@@ -1,13 +1,13 @@
 package com.kustaurant.kustaurant.admin.RestaurantCrawl.controller.dto;
 
 import com.kustaurant.map.ZoneType;
-import com.kustaurant.restaurantSync.sync.ZoneJCrawlobStatus;
+import com.kustaurant.restaurantSync.sync.ZoneCrawlJobStatus;
 import java.util.List;
 
 public record ZoneCrawlJobStatusResponse(
         // 프론트 렌더링용
         ZoneType crawlScope,
-        ZoneJCrawlobStatus status,
+        ZoneCrawlJobStatus status,
         String currentPhase,
         int totalGridCount,
         int processedGridCount,

--- a/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/infrastructure/RestaurantCrawlerClient.java
+++ b/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/infrastructure/RestaurantCrawlerClient.java
@@ -129,6 +129,24 @@ public class RestaurantCrawlerClient {
         }
     }
 
+    public CrawlJobIdResponse resumeZoneCrawlJob(String jobId) {
+        try {
+            log.info("네이버플레이스 구역 크롤 작업 재개 요청. jobId={}", jobId);
+            return webClient.post()
+                    .uri("/api/naver-place/crawl-zone/jobs/{jobId}/resume", jobId)
+                    .retrieve()
+                    .onStatus(
+                            HttpStatusCode::isError,
+                            res -> res.bodyToMono(String.class)
+                                    .map(body -> new IllegalStateException("네이버플레이스 구역 크롤 작업 재개 오류: " + body))
+                    )
+                    .bodyToMono(CrawlJobIdResponse.class)
+                    .block(Duration.ofSeconds(20));
+        } catch (WebClientRequestException e) {
+            throw new IllegalStateException("크롤러 서버에 연결할 수 없습니다. crawler.base-url과 서버 상태를 확인하세요.", e);
+        }
+    }
+
     public ZoneCrawlJobResultsPayload getZoneCrawlJobResults(String jobId, int fromIndex, int limit) {
         try {
             return webClient.get()

--- a/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/service/ZoneCrawlJobService.java
+++ b/server/kustaurant/src/main/java/com/kustaurant/kustaurant/admin/RestaurantCrawl/service/ZoneCrawlJobService.java
@@ -7,7 +7,7 @@ import com.kustaurant.restaurantSync.RestaurantRaw;
 import com.kustaurant.restaurantSync.sync.CrawlJobIdResponse;
 import com.kustaurant.restaurantSync.sync.ZoneCrawlStatusPayload;
 import com.kustaurant.restaurantSync.sync.ZoneCrawlJobResultsPayload;
-import com.kustaurant.restaurantSync.sync.ZoneJCrawlobStatus;
+import com.kustaurant.restaurantSync.sync.ZoneCrawlJobStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +16,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,16 @@ public class ZoneCrawlJobService {
    private final RestaurantRawSaveService rawSaveService;
 
    private final Map<String, ZoneCrawlJobState> jobs = new ConcurrentHashMap<>();
-   private final ExecutorService executor = Executors.newCachedThreadPool();
+   private final ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+      Thread thread = new Thread(runnable, "zone-crawl-sync-worker");
+      thread.setDaemon(true);
+      return thread;
+   });
+
+   @PreDestroy
+   void shutdownExecutor() {
+      executor.shutdownNow();
+   }
 
    public CrawlJobIdResponse start(ZoneType crawlScope) {
       String jobId = UUID.randomUUID().toString();
@@ -48,36 +58,68 @@ public class ZoneCrawlJobService {
       return Optional.ofNullable(jobs.get(jobId)).map(ZoneCrawlJobState::toResponse);
    }
 
+   public Optional<CrawlJobIdResponse> resume(String jobId) {
+      ZoneCrawlJobState state = jobs.get(jobId);
+      if (state == null) {
+         return Optional.empty();
+      }
+
+      state.markResumeQueued();
+      executor.submit(() -> runJob(state, true));
+      log.info("구역 동기화 작업 재개 등록. jobId={}, crawlerJobId={}", jobId, state.crawlerJobId);
+      return Optional.of(new CrawlJobIdResponse(jobId));
+   }
+
    private void runJob(ZoneCrawlJobState state) {
+      runJob(state, false);
+   }
+
+   private void runJob(ZoneCrawlJobState state, boolean resume) {
       state.markRunning();
       try {
-         state.currentPhase = "CRAWL_JOB_START";
-         CrawlJobIdResponse startResponse = crawlerClient.startZoneCrawlJob(state.crawlScope);
-         state.crawlerJobId = startResponse.jobId();
+         if (resume) {
+            state.currentPhase = "CRAWL_JOB_RESUME";
+            crawlerClient.resumeZoneCrawlJob(state.crawlerJobId);
+         } else {
+            state.currentPhase = "CRAWL_JOB_START";
+            CrawlJobIdResponse startResponse = crawlerClient.startZoneCrawlJob(state.crawlScope);
+            state.crawlerJobId = startResponse.jobId();
+         }
          state.currentPhase = "CRAWL_RUNNING";
-         int nextResultIndex = 0;
 
          while (true) {
             ZoneCrawlStatusPayload crawlStatus = crawlerClient.getZoneCrawlJobStatus(state.crawlerJobId);
             state.applyCrawlerStatus(crawlStatus);
 
             state.currentPhase = "SAVE_RAW_STREAMING";
-            nextResultIndex = fetchAndSaveIncrementalResults(state, nextResultIndex);
+            state.nextResultIndex = fetchAndSaveIncrementalResults(state, state.nextResultIndex);
 
-            if (crawlStatus.status() == ZoneJCrawlobStatus.SUCCESS) {
+            if (crawlStatus.status() == ZoneCrawlJobStatus.CAPTCHA_REQUIRED) {
+               state.markCaptchaRequired(crawlStatus);
+               log.warn(
+                       "구역 동기화 작업 보안 인증 대기. jobId={}, crawlerJobId={}, grid={}, preservedPlaceCount={}",
+                       state.jobId,
+                       state.crawlerJobId,
+                       state.currentGrid,
+                       state.discoveredPlaceCount
+               );
+               return;
+            }
+
+            if (crawlStatus.status() == ZoneCrawlJobStatus.SUCCESS) {
                state.currentPhase = "SAVE_RAW_FINALIZE";
-               nextResultIndex = fetchAndSaveIncrementalResults(state, nextResultIndex);
+               state.nextResultIndex = fetchAndSaveIncrementalResults(state, state.nextResultIndex);
 
                state.markSuccess();
                log.info(
                        "구역 동기화 작업 완료. jobId={}, scope={}, discoveredPlaceCount={}, crawledSuccessCount={}, savedRawCount={}, saveFailedCount={}, lastSavedIndex={}",
                        state.jobId, state.crawlScope, state.discoveredPlaceCount, state.crawledSuccessCount,
-                       state.savedRawCount, state.saveFailedCount, nextResultIndex
+                       state.savedRawCount, state.saveFailedCount, state.nextResultIndex
                );
                break;
             }
 
-            if (crawlStatus.status() == ZoneJCrawlobStatus.FAILED) {
+            if (crawlStatus.status() == ZoneCrawlJobStatus.FAILED) {
                throw new IllegalStateException("크롤 작업 실패: " + crawlStatus.errorMessage());
             }
 
@@ -151,7 +193,7 @@ public class ZoneCrawlJobService {
       private final String jobId;
       private final ZoneType crawlScope;
 
-      private volatile ZoneJCrawlobStatus status;
+      private volatile ZoneCrawlJobStatus status;
       private volatile String crawlerJobId;
       private volatile String currentPhase;
       private volatile int totalGridCount;
@@ -163,6 +205,7 @@ public class ZoneCrawlJobService {
       private volatile List<String> finalFailedPlaceIds = List.of();
       private volatile int savedRawCount;
       private volatile int saveFailedCount;
+      private volatile int nextResultIndex;
       private volatile String currentGrid;
       private volatile String currentPlaceId;
       private volatile String errorMessage;
@@ -172,7 +215,7 @@ public class ZoneCrawlJobService {
       private ZoneCrawlJobState(String jobId, ZoneType crawlScope) {
          this.jobId = jobId;
          this.crawlScope = crawlScope;
-         this.status = ZoneJCrawlobStatus.PENDING;
+         this.status = ZoneCrawlJobStatus.PENDING;
       }
 
       private static ZoneCrawlJobState pending(String jobId, ZoneType crawlScope) {
@@ -180,19 +223,45 @@ public class ZoneCrawlJobService {
       }
 
       private void markRunning() {
-         this.status = ZoneJCrawlobStatus.RUNNING;
+         this.status = ZoneCrawlJobStatus.RUNNING;
          this.currentPhase = "QUEUED";
-         this.startedAt = LocalDateTime.now();
+         this.errorMessage = null;
+         this.finishedAt = null;
+         if (this.startedAt == null) {
+            this.startedAt = LocalDateTime.now();
+         }
+      }
+
+      private synchronized void markResumeQueued() {
+         if (status != ZoneCrawlJobStatus.CAPTCHA_REQUIRED) {
+            throw new IllegalStateException(
+                    "보안 인증 대기 상태의 작업만 재개할 수 있습니다. status=" + status
+            );
+         }
+         if (crawlerJobId == null || crawlerJobId.isBlank()) {
+            throw new IllegalStateException("재개할 크롤러 작업 ID가 없습니다.");
+         }
+         this.status = ZoneCrawlJobStatus.RUNNING;
+         this.currentPhase = "RESUME_QUEUED";
+         this.errorMessage = null;
+         this.finishedAt = null;
+      }
+
+      private void markCaptchaRequired(ZoneCrawlStatusPayload crawlStatus) {
+         this.status = ZoneCrawlJobStatus.CAPTCHA_REQUIRED;
+         this.currentPhase = "CAPTCHA_REQUIRED";
+         this.errorMessage = crawlStatus.errorMessage();
+         this.finishedAt = null;
       }
 
       private void markSuccess() {
-         this.status = ZoneJCrawlobStatus.SUCCESS;
+         this.status = ZoneCrawlJobStatus.SUCCESS;
          this.currentPhase = "COMPLETED";
          this.finishedAt = LocalDateTime.now();
       }
 
       private void markFailed(Exception e) {
-         this.status = ZoneJCrawlobStatus.FAILED;
+         this.status = ZoneCrawlJobStatus.FAILED;
          this.errorMessage = e.getMessage();
          this.finishedAt = LocalDateTime.now();
       }

--- a/server/kustaurant/src/main/resources/static/js/admin/admin-crawl.js
+++ b/server/kustaurant/src/main/resources/static/js/admin/admin-crawl.js
@@ -215,8 +215,15 @@ function renderNaverPlaceZoneCrawlResult(data) {
         ${data.errorMessage ? `<div><strong>에러:</strong> ${data.errorMessage}</div>` : ""}
         <div><strong>최종 실패 수:</strong> ${data.finalFailedCount || 0}</div>
         <div><strong>최종 실패 placeId:</strong> ${finalFailedIds || "-"}</div>
+        ${data.status === "CAPTCHA_REQUIRED" ? `
+            <div><strong>처리:</strong> 완료된 그리드와 발견 ID는 보존되었습니다.</div>
+            <button type="button" id="naver-place-zone-resume-btn">실패 그리드부터 재시도</button>
+        ` : ""}
     `;
     resultBox.classList.remove("hidden");
+
+    document.getElementById("naver-place-zone-resume-btn")
+        ?.addEventListener("click", resumeNaverPlaceZoneCrawl);
 }
 
 function pollNaverPlaceZoneCrawlStatus(jobId, submitBtn) {
@@ -232,6 +239,11 @@ function pollNaverPlaceZoneCrawlStatus(jobId, submitBtn) {
         .then(parseJsonResponse)
         .then(data => {
             renderNaverPlaceZoneCrawlResult(data);
+            if (data.status === "CAPTCHA_REQUIRED") {
+                submitBtn.textContent = "보안 인증 대기";
+                stopNaverPlaceZoneCrawlPolling();
+                return;
+            }
             if (isZoneCrawlJobFinished(data.status)) {
                 activeNaverPlaceZoneCrawlJobId = null;
                 submitBtn.disabled = false;
@@ -247,6 +259,42 @@ function pollNaverPlaceZoneCrawlStatus(jobId, submitBtn) {
             submitBtn.textContent = "구역 크롤 시작";
             stopNaverPlaceZoneCrawlPolling();
             alert(`구역 크롤 상태 조회 실패: ${error.message}`);
+        });
+}
+
+function resumeNaverPlaceZoneCrawl() {
+    const jobId = activeNaverPlaceZoneCrawlJobId;
+    const submitBtn = document.getElementById("naver-place-sync-submit-btn");
+    const resumeBtn = document.getElementById("naver-place-zone-resume-btn");
+    if (!jobId || !submitBtn) return;
+
+    if (resumeBtn) {
+        resumeBtn.disabled = true;
+        resumeBtn.textContent = "재개 요청 중...";
+    }
+
+    fetch(`/admin/api/crawl/naver-place/crawl-zone/jobs/${jobId}/resume`, {
+        method: "POST",
+        headers: {
+            "Accept": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+            "X-XSRF-TOKEN": getCookie("XSRF-TOKEN")
+        }
+    })
+        .then(parseJsonResponse)
+        .then(() => {
+            submitBtn.disabled = true;
+            submitBtn.textContent = "재개 중...";
+            stopNaverPlaceZoneCrawlPolling();
+            pollNaverPlaceZoneCrawlStatus(jobId, submitBtn);
+        })
+        .catch(error => {
+            console.error("zone crawl resume failed:", error);
+            if (resumeBtn) {
+                resumeBtn.disabled = false;
+                resumeBtn.textContent = "실패 그리드부터 재시도";
+            }
+            alert(`구역 크롤 재개 실패: ${error.message}`);
         });
 }
 


### PR DESCRIPTION
## 개요

이번 변경은 크게 **네이버 식당 갱신 크롤 과정 개선**과 **테스트 실행 체계 표준화** 두 부분으로 구성됩니다.

1. 네이버 식당 크롤링시 graphQL을 파싱해 크롤링 하려던 시도가 안되는 원인을 찾아 해결했습니다.
2. 기존 테스트 실행 체계가 적절하지 못했음을 인지하고, 개선했습니다.

### 1. 네이버 식당 갱신 크롤 과정 개선

#### 기존 로직

- 네이버 플레이스의 home/menu HTML 응답을 받은 뒤, 난독화된 CSS 선택자를 이용해 DOM에서 식당 기본 정보와 메뉴를 추출했습니다.
- 식당 하나를 처리할 때마다 Playwright 브라우저·컨텍스트를 새로 생성했고, 식당 사이에 3~5초 랜덤 대기가 있었습니다.
- 메뉴 데이터 유무와 관계없이 메뉴 화면 로딩에 의존하는 구간이 있었습니다.
- 그리드 탐색 실패가 빈 결과로 처리될 수 있었고, 캡차와 일반 실패를 구분하지 못해 이미 수집한 진행 상태를 명확하게 보존하기 어려웠습니다.
- 그리드 수집 실패 시 원인과 관계없이 일정 간격으로 자동 재시도했기 때문에, 네이버의 크롤링 방지용 캡차가 발생한 경우에도 성공 가능성이 낮은 요청을 반복했습니다.
- 구역 크롤 작업의 동시 실행 제한이 없어 여러 작업이 동시에 브라우저를 사용할 수 있었습니다.

#### 개선 로직

- HTML에 포함되어 브라우저로 전달되는 `window.__APOLLO_STATE__` 캐시를 먼저 파싱해 이름, 주소, 전화번호, 좌표, 이미지, 메뉴 등을 추출합니다.
- Apollo 캐시가 없거나 일부 필드가 비어 있을 때만 기존 DOM 추출을 필드 단위 fallback으로 사용합니다.
- Apollo 캐시에 메뉴 데이터가 있으면 메뉴 화면을 열지 않고, 메뉴 데이터가 없을 때만 기존 DOM 메뉴 추출을 수행합니다.
- 구역 작업 하나에서는 Playwright 브라우저·컨텍스트를 재사용하고 식당별 페이지만 분리하며, 식당 사이의 3~5초 랜덤 대기를 제거했습니다.
- 네이버의 캡차를 풀거나 우회하지 않고 보안 인증 화면을 감지하면 자동 재시도를 즉시 중단합니다. 캡차는 세션이나 요청 주기에 대한 제한이 유지되는 동안 짧은 간격으로 다시 요청해도 같은 실패가 반복될 가능성이 높기 때문입니다.
- 캡차 발생 시 작업을 `CAPTCHA_REQUIRED` 상태로 전환하고, 완료된 그리드와 발견한 placeId를 체크포인트로 보존합니다. 이후 사용자가 어드민 화면의 `실패 그리드부터 재시도` 버튼을 눌러 새 브라우저 세션에서 멈춘 그리드부터 직접 재개할 수 있도록 했습니다.
- 캡차가 아닌 일시적인 그리드 탐색 오류에 대해서만 제한된 자동 재시도를 유지하고, 재시도 소진 시 빈 결과로 숨기지 않고 명시적인 실패로 처리합니다.
- 동시에 실행할 수 있는 구역 크롤 작업과 Playwright 브라우저를 1개로 제한했습니다.
- 운영 크롤러와 테스트 크롤러가 동일한 그리드 기본값을 사용하도록 공통 상수로 정리했습니다.

#### 속도 비교

비교 조건은 다음과 같습니다.

- 5개 구역별로 고정된 네이버 식당 placeId 10개를 같은 순서로 상세 수집
- 기존 방식: 식당별 브라우저 생성 + DOM 중심 추출 + 식당 사이 3~5초 랜덤 대기
- 개선 방식: 브라우저·컨텍스트 재사용 + Apollo 우선 추출 + 랜덤 대기 제거

| 구역 | 기존 방식 | 개선 방식 | 시간 단축 |
| --- | ---: | ---: | ---: |
| 건입~중문 | 240.2초 | 49.0초 | 79.6% |
| 중문~어대 | 252.6초 | 39.5초 | 84.4% |
| 후문 | 238.3초 | 64.1초 | 73.1% |
| 정문 | 247.5초 | 38.1초 | 84.6% |
| 구의역 | 231.1초 | 55.3초 | 76.1% |

- 5개 구역 총 소요 시간: **20분 10초 → 4분 6초**
- 구역당 평균 소요 시간: **4분 2초 → 49초**
- 전체 소요 시간 기준: **79.7% 단축**

> 이 벤치마크는 구역별 고정 식당 10개의 상세 수집 성능을 비교한 결과입니다. 전체 구역의 모든 식당을 수집하는 운영 시간은 네이버 응답 속도, 식당 수, 재시도 및 캡차 발생 여부에 따라 달라질 수 있습니다.

### 2. 테스트 실행 체계 표준화

소형·중형 테스트 구분은 유지하되, Gradle·IntelliJ·GitHub Actions가 같은 태스크와 결과 경로를 사용하도록 실행 구조를 정리했습니다.

#### 기존 구조

- 기본 Gradle `test` 태스크가 비활성화되어 있었습니다.
- 소형 테스트를 별도 `smallTest` 태스크로 다시 정의했고, 중형 테스트 source set과 실행 태스크 이름도 `middleTest`로 달랐습니다.
- 이 구조 때문에 IntelliJ에서 표준 테스트 실행 시 테스트 이벤트를 받지 못하거나, 테스트 트리와 개별 통과 결과가 표시되지 않는 경우가 있었습니다.
- CI가 별도 태스크명과 결과 경로를 사용해 로컬 실행 방식과 어긋나 있었습니다.

#### 개선 구조

- 소형 테스트는 Gradle 표준 `test` 태스크를 그대로 사용합니다.
- 중형/통합 테스트는 `integrationTest` source set과 동일한 이름의 `integrationTest` 태스크로 실행합니다.
- `check` 실행 시 소형 테스트 후 중형 테스트가 이어서 실행되도록 연결했습니다.
- 불필요한 `smallTest`, `middleTest` 별칭 태스크는 제거했습니다.
- IntelliJ의 Gradle 테스트 러너가 표준 테스트 이벤트를 받아 테스트 트리와 클래스·메서드별 성공 여부를 표시할 수 있도록 했습니다.
- 개발 환경의 Testcontainers 호환을 위해 Docker API 버전을 테스트 리소스에 명시하고, 통합 테스트에서 사용하지 않는 크롤러 주소에는 테스트용 값을 추가했습니다.
- GitHub Actions도 `:server:kustaurant:test`, `:server:kustaurant:integrationTest`를 실행하고 각각의 표준 XML 결과 경로를 게시하도록 수정했습니다.

### 검증

- 크롤러 신규·변경 관련 테스트: **22개 통과**
- 5개 구역 × 식당 10개 상세 수집 벤치마크 완료
- 성능 벤치마크 테스트는 환경변수 미설정 시 1개 조건부 스킵
- 참고: 기존 크롤러 `contextLoads()`는 테스트 프로필의 `instagram.username` 누락으로 1개 실패하며 이번 변경 범위에는 포함하지 않았습니다.

<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
